### PR TITLE
Bp 4 swagger configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,22 @@
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+buildscript {
+    ext {
+        restdocsApiSpecVersion = '0.19.2'
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
     id "org.sonarqube" version "4.4.1.3373"
-
+    id 'com.epages.restdocs-api-spec' version '0.19.2'
+    id 'org.hidetake.swagger.generator' version '2.19.2'
 }
+
+
 
 group = 'gdsc.konkuk'
 version = '0.0.1-SNAPSHOT'
@@ -40,10 +52,56 @@ dependencies {
     //test dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'com.epages:restdocs-api-spec:0.19.2'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+    swaggerUI 'org.webjars:swagger-ui:5.0.0'
 }
+
+openapi3 {
+    servers = [
+            { url = 'http://localhost:8080' },
+    ]
+    title = 'Post Service API'
+    description = 'Post Service API description'
+    version = '1.0.0'
+    format = 'yaml'
+}
+
+swaggerSources {
+    sample {
+        setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+    }
+}
+
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(GenerateSwaggerUI).configureEach {
+    dependsOn 'openapi3'
+}
+
+tasks.register('copySwaggerUI', Copy) {
+    dependsOn 'generateSwaggerUISample'
+
+    def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+
+    from("${generateSwaggerUISampleTask.outputDir}")
+    into("${project.buildDir}/resources/main/static/docs")
+}
+
+tasks.resolveMainClassName {
+    dependsOn 'copySwaggerUI'
+}
+
+tasks.withType(BootJar).configureEach {
+    dependsOn 'copySwaggerUI'
+}
+
+tasks.named('jar').configure {
+    dependsOn 'copySwaggerUI'
 }
 
 // sonarqube plugins

--- a/src/main/java/gdsc/konkuk/platformcore/controller/SwaggerController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/SwaggerController.java
@@ -1,0 +1,21 @@
+package gdsc.konkuk.platformcore.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+
+@RestController
+@RequestMapping("/swagger")
+
+public class SwaggerController {
+
+	@GetMapping()
+	public ResponseEntity<String> swaggerTest() {
+		String swaggerComment = "Hi This is swagger Test Controller";
+		return ResponseEntity.ok(swaggerComment);
+	}
+
+}

--- a/src/test/java/gdsc/konkuk/platformcore/APIDocumentationTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/APIDocumentationTest.java
@@ -1,0 +1,45 @@
+package gdsc.konkuk.platformcore;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+import gdsc.konkuk.platformcore.annotation.RestDocsTest;
+import gdsc.konkuk.platformcore.controller.SwaggerController;
+
+@DisplayName("스웨거API 테스트 문서화 예시")
+@RestDocsTest
+@WebMvcTest(SwaggerController.class)
+class APIDocumentationTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Test
+	void swaggerGetTest() throws Exception {
+			mockMvc.perform(
+					RestDocumentationRequestBuilders.get("/swagger")
+				)
+				.andExpect(status().isOk())
+				.andDo(MockMvcRestDocumentationWrapper.document("test-get",
+					ResourceSnippetParameters.builder()
+						.tag("테스트")
+						.summary("Get 테스트")
+						.description("Get 테스트")
+					,
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint())
+				));
+
+		}
+
+}

--- a/src/test/java/gdsc/konkuk/platformcore/annotation/RestDocsTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/annotation/RestDocsTest.java
@@ -1,0 +1,24 @@
+package gdsc.konkuk.platformcore.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.restdocs.RestDocumentationExtension;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Tag("restDocs")
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+public @interface RestDocsTest {
+}


### PR DESCRIPTION
### 작업내역

- 협업을 위한 **스웨거 및 RestDocs** 도입
- **스웨거만을 도입 시 코드에 스웨거로 인한 코드들이 추가되는 것**으로 인해서 RestDocs와 함께 사용
- RestDocs가 생성하는 파일을 기반으로 스웨거 파일들을 생성, {api}/docs/index.html 에서 확인가능
![Screenshot 2024-07-12 at 12 32 06 AM](https://github.com/gdsc-konkuk/platform-core/assets/76658405/4bdc107c-6e22-452a-97b0-3a74822a73e5)

### 주목할 사항
- RestDocs를 도입하는 부분에서 테스트코드를 무조건 작성해야한다는 점이 고려할 점이었습니다.
- 테스트 코드를 작성함으로써 코드의 불안정성을 낮출 수 있기 때문에 문제될 점이 아니라고 판단하여 도입했어요
