### PR TITLE
fix : 이메일 저장후 바로 조회 시 조회가 안되는 이슈 수정

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
@@ -10,6 +10,7 @@ import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -31,7 +32,7 @@ public class EmailService {
     return emailTaskRepository.findAllWhereNotSent();
   }
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public EmailTask registerTask(EmailTask emailTask) {
     return emailTaskRepository.save(emailTask);
   }

--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailTaskScheduler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailTaskScheduler.java
@@ -50,7 +50,7 @@ public class EmailTaskScheduler implements TaskScheduler {
           } finally {
             taskInMemoryRepository.removeTask(String.valueOf(id));
           }
-        };
+    };
     ScheduledFuture<?> future = executor.schedule(sendEmailTask, delay, SECONDS);
     taskInMemoryRepository.addTask(String.valueOf(email.getId()), future);
   }

--- a/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordClient.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordClient.java
@@ -1,6 +1,8 @@
 package gdsc.konkuk.platformcore.external.discord;
 
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -8,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DiscordClient {
@@ -22,6 +25,10 @@ public class DiscordClient {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     HttpEntity<DiscordMessage> entity = new HttpEntity<>(message, headers);
-    restTemplate.postForObject(WEB_HOOK_URL, entity, String.class);
+    try {
+      restTemplate.postForObject(WEB_HOOK_URL, entity, String.class);
+    } catch (Exception ex) {
+      log.error(Arrays.toString(ex.getStackTrace()));
+    }
   }
 }

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
@@ -96,7 +96,7 @@ class EmailServiceTest {
             .receivers(List.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
-    given(emailTaskRepository.saveAndFlush(any(EmailTask.class))).willReturn(mock1);
+    given(emailTaskRepository.save(any(EmailTask.class))).willReturn(mock1);
     // when
     EmailTask expected = EmailSendRequest.toEntity(emailRequest);
     EmailTask actual = subject.registerTask(EmailSendRequest.toEntity(emailRequest));

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
@@ -86,7 +86,7 @@ class EmailServiceTest {
 
   @Test
   @DisplayName("registerTask : 이메일 전송 작업 등록 성공")
-  void sholud_success_when_register_task() {
+  void should_success_when_register_task() {
     // given
 
     EmailSendRequest emailRequest =
@@ -96,7 +96,7 @@ class EmailServiceTest {
             .receivers(List.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
-    given(emailTaskRepository.save(any(EmailTask.class))).willReturn(mock1);
+    given(emailTaskRepository.saveAndFlush(any(EmailTask.class))).willReturn(mock1);
     // when
     EmailTask expected = EmailSendRequest.toEntity(emailRequest);
     EmailTask actual = subject.registerTask(EmailSendRequest.toEntity(emailRequest));


### PR DESCRIPTION
디스코드 전송과정에서 에러가 생긴경우 로그에 표시

트랜잭션 범위에따라 멀티스레드에서 다른 트랜잭션이 먼저 조회하면 null이 발생하는 상황 발견
save는 별도의 트랜잭션을 생성해서 커밋 후 다음 로직 진행하도록 변경