### PR TITLE
Fix jpa element collection type

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/dto/EmailSendRequest.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/dto/EmailSendRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,12 +20,12 @@ public class EmailSendRequest {
   @NotEmpty
   private String content;
   @NotNull
-  private List<@Email String> receivers;
+  private Set<@Email String> receivers;
   @NotNull
   private LocalDateTime sendAt;
 
   @Builder
-  public EmailSendRequest(String subject, String content, List<String> receivers, LocalDateTime sendAt) {
+  public EmailSendRequest(String subject, String content, Set<String> receivers, LocalDateTime sendAt) {
     this.subject = subject;
     this.content = content;
     this.receivers = receivers;

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/dto/EmailTaskDetailsResponse.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/dto/EmailTaskDetailsResponse.java
@@ -18,7 +18,10 @@ public class EmailTaskDetailsResponse {
   public EmailTaskDetailsResponse(EmailDetails emailDetails, EmailReceivers emailReceivers, LocalDateTime sendAt) {
     this.subject = emailDetails.getSubject();
     this.content = emailDetails.getContent();
-    this.receivers = emailReceivers.getReceivers();
+    this.receivers = emailReceivers
+        .getReceivers()
+        .stream()
+        .toList();
     this.sendAt = sendAt;
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
@@ -3,13 +3,13 @@ package gdsc.konkuk.platformcore.domain.email.entity;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
 import jakarta.persistence.Embeddable;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,12 +20,9 @@ import lombok.NoArgsConstructor;
 public class EmailReceivers {
 
   @ElementCollection
-  @CollectionTable(
-      name = "email_receivers",
-      joinColumns = @JoinColumn(name = "task_id")
-  )
+  @CollectionTable(name = "email_receivers", joinColumns = @JoinColumn(name = "task_id"))
   @Column(name = "receiver_email")
-  List<String> receivers = new ArrayList<>();
+  Set<String> receivers = new HashSet<>();
 
   public EmailReceivers(List<String> receivers) {
     this.receivers.addAll(receivers);

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.JoinColumn;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 
 import jakarta.persistence.Embeddable;
@@ -24,7 +23,7 @@ public class EmailReceivers {
   @Column(name = "receiver_email")
   Set<String> receivers = new HashSet<>();
 
-  public EmailReceivers(List<String> receivers) {
+  public EmailReceivers(Set<String> receivers) {
     this.receivers.addAll(receivers);
   }
 
@@ -39,5 +38,13 @@ public class EmailReceivers {
     if (o == null || getClass() != o.getClass()) return false;
     EmailReceivers that = (EmailReceivers) o;
     return Objects.equals(receivers, that.receivers);
+  }
+
+  public void removeAll() {
+    this.receivers.clear();
+  }
+
+  public void insertAll(Set<String> set) {
+    this.receivers.addAll(set);
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTask.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTask.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -48,8 +50,9 @@ public class EmailTask {
     emailDetails = newEmailDetails;
   }
 
-  public void changeEmailReceivers(final EmailReceivers newEmailReceivers) {
-    emailReceivers = newEmailReceivers;
+  public void changeEmailReceivers(final Set<String> set) {
+    emailReceivers.removeAll();
+    emailReceivers.insertAll(set);
   }
 
   public void changeSendAt(final LocalDateTime newSendAt) {
@@ -58,5 +61,19 @@ public class EmailTask {
 
   public void markAsSent() {
     isSent = true;
+  }
+
+  public List<String> filterReceiversInPrevSet(Set<String> set) {
+    return this.getEmailReceivers().getReceivers()
+        .stream()
+        .filter(set::contains)
+        .toList();
+  }
+
+  public List<String> filterReceiversNotInPrevSet(Set<String> set) {
+    return set
+        .stream()
+        .filter((e) -> !emailReceivers.getReceivers().contains(e))
+        .toList();
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/external/email/EmailClient.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/email/EmailClient.java
@@ -1,7 +1,6 @@
 package gdsc.konkuk.platformcore.external.email;
 
-import java.util.List;
-
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -27,7 +26,7 @@ public class EmailClient {
 
   public void sendEmailToReceivers(EmailTask email) {
     EmailDetails emailDetails = email.getEmailDetails();
-    List<String> receivers = email.getEmailReceivers().getReceivers();
+    Set<String> receivers = email.getEmailReceivers().getReceivers();
     receivers.forEach(receiver -> sendEmail(receiver, emailDetails));
   }
 

--- a/src/test/java/gdsc/konkuk/platformcore/annotation/CustomMockUser.java
+++ b/src/test/java/gdsc/konkuk/platformcore/annotation/CustomMockUser.java
@@ -1,11 +1,9 @@
 package gdsc.konkuk.platformcore.annotation;
 
+import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-
 import org.springframework.security.test.context.support.WithSecurityContext;
-
-import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMyCustomUserSecurityContextFactory.class)

--- a/src/test/java/gdsc/konkuk/platformcore/annotation/RestDocsTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/annotation/RestDocsTest.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/src/test/java/gdsc/konkuk/platformcore/annotation/WithMyCustomUserSecurityContextFactory.java
+++ b/src/test/java/gdsc/konkuk/platformcore/annotation/WithMyCustomUserSecurityContextFactory.java
@@ -1,7 +1,7 @@
 package gdsc.konkuk.platformcore.annotation;
 
+import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import java.util.List;
-
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -9,8 +9,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
-
-import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 
 public class WithMyCustomUserSecurityContextFactory implements WithSecurityContextFactory<CustomMockUser> {
   @Override

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailIntegrationTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailIntegrationTest.java
@@ -20,7 +20,7 @@ import gdsc.konkuk.platformcore.global.exceptions.GlobalErrorCode;
 import gdsc.konkuk.platformcore.global.exceptions.TaskNotFoundException;
 import gdsc.konkuk.platformcore.global.scheduler.TaskInMemoryRepository;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -72,7 +72,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusHours(1))
             .build();
     // when
@@ -92,7 +92,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1@gmail.com", "example2@gmail.com"))
+            .receivers(Set.of("example1@gmail.com", "example2@gmail.com"))
             .sendAt(LocalDateTime.now().plusSeconds(5L))
             .build();
     // when
@@ -120,7 +120,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusHours(1))
             .build();
     EmailTask emailTask = emailTaskFacade.register(emailRequest);
@@ -130,7 +130,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusHours(2))
             .build();
     // when
@@ -156,7 +156,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusHours(1))
             .build();
     EmailTask emailTask = emailTaskFacade.register(emailRequest);
@@ -182,7 +182,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusSeconds(1L))
             .build();
     //when
@@ -202,7 +202,7 @@ class EmailIntegrationTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusSeconds(1L))
             .build();
     doThrow(EmailSendingException.of(GlobalErrorCode.INTERNAL_SERVER_ERROR))

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceHelperTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceHelperTest.java
@@ -10,8 +10,8 @@ import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -25,7 +25,7 @@ class EmailServiceHelperTest {
       EmailTask.builder()
           .id(1L)
           .emailDetails(new EmailDetails("subject", "content"))
-          .receivers(new EmailReceivers(List.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
           .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
           .build();
 

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
@@ -14,6 +14,7 @@ import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class EmailServiceTest {
       EmailTask.builder()
           .id(1L)
           .emailDetails(new EmailDetails("subject", "content"))
-          .receivers(new EmailReceivers(List.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
           .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
           .build();
 
@@ -37,7 +38,7 @@ class EmailServiceTest {
       EmailTask.builder()
           .id(2L)
           .emailDetails(new EmailDetails("subject2", "content2"))
-          .receivers(new EmailReceivers(List.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
           .sendAt(LocalDateTime.now())
           .build();
   List<EmailTask> mockEmailTaskList = List.of(mock1, mock2);
@@ -45,7 +46,7 @@ class EmailServiceTest {
       EmailTask.builder()
           .id(3L)
           .emailDetails(new EmailDetails("subject3", "content3"))
-          .receivers(new EmailReceivers(List.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
           .sendAt(LocalDateTime.now())
           .build();
 
@@ -93,7 +94,7 @@ class EmailServiceTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
     given(emailTaskRepository.save(any(EmailTask.class))).willReturn(mock1);
@@ -114,7 +115,7 @@ class EmailServiceTest {
         EmailSendRequest.builder()
             .subject("subject2")
             .content("content2")
-            .receivers(List.of("example2.com", "example4.com"))
+            .receivers(Set.of("example2.com", "example4.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
     given(emailTaskRepository.findById(1L)).willReturn(java.util.Optional.of(mock1));
@@ -134,7 +135,7 @@ class EmailServiceTest {
         EmailSendRequest.builder()
             .subject("subject2")
             .content("content2")
-            .receivers(List.of("example2.com", "example4.com"))
+            .receivers(Set.of("example2.com", "example4.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
     // when
@@ -151,7 +152,7 @@ class EmailServiceTest {
         EmailSendRequest.builder()
             .subject("subject2")
             .content("content2")
-            .receivers(List.of("example2.com", "example4.com"))
+            .receivers(Set.of("example2.com", "example4.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
     // when

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailTaskFacadeTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailTaskFacadeTest.java
@@ -10,7 +10,7 @@ import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.global.scheduler.TaskScheduler;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class EmailTaskFacadeTest {
       EmailTask.builder()
           .id(1L)
           .emailDetails(new EmailDetails("subject", "content"))
-          .receivers(new EmailReceivers(List.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
           .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
           .build();
 
@@ -49,7 +49,7 @@ class EmailTaskFacadeTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(List.of("example1.com", "example2.com"))
+            .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
     //when

--- a/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
@@ -3,10 +3,15 @@ package gdsc.konkuk.platformcore.application.member;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.Optional;
-
+import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyDeletedException;
+import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
+import gdsc.konkuk.platformcore.application.member.exceptions.UserNotFoundException;
+import gdsc.konkuk.platformcore.controller.member.MemberRegisterRequest;
 import gdsc.konkuk.platformcore.domain.attendance.repository.AttendanceRepository;
 import gdsc.konkuk.platformcore.domain.attendance.repository.ParticipantRepository;
+import gdsc.konkuk.platformcore.domain.member.entity.Member;
+import gdsc.konkuk.platformcore.domain.member.repository.MemberRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,13 +19,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyDeletedException;
-import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
-import gdsc.konkuk.platformcore.application.member.exceptions.UserNotFoundException;
-import gdsc.konkuk.platformcore.controller.member.MemberRegisterRequest;
-import gdsc.konkuk.platformcore.domain.member.entity.Member;
-import gdsc.konkuk.platformcore.domain.member.repository.MemberRepository;
 
 class MemberServiceTest {
 

--- a/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
@@ -1,31 +1,5 @@
 package gdsc.konkuk.platformcore.controller.attendance;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gdsc.konkuk.platformcore.application.attendance.AttendanceService;
-import gdsc.konkuk.platformcore.application.event.EventService;
-import gdsc.konkuk.platformcore.application.event.EventWithAttendance;
-import gdsc.konkuk.platformcore.domain.attendance.entity.Participant;
-
-import java.time.LocalDate;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
@@ -44,6 +18,30 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gdsc.konkuk.platformcore.application.attendance.AttendanceService;
+import gdsc.konkuk.platformcore.application.event.EventService;
+import gdsc.konkuk.platformcore.application.event.EventWithAttendance;
+import gdsc.konkuk.platformcore.domain.attendance.entity.Participant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @ExtendWith({RestDocumentationExtension.class})

--- a/src/test/java/gdsc/konkuk/platformcore/controller/auth/AuthControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/auth/AuthControllerTest.java
@@ -3,39 +3,32 @@ package gdsc.konkuk.platformcore.controller.auth;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import gdsc.konkuk.platformcore.domain.member.entity.Member;
+import gdsc.konkuk.platformcore.domain.member.repository.MemberRepository;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
-
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-
-import gdsc.konkuk.platformcore.domain.member.entity.Member;
-import gdsc.konkuk.platformcore.domain.member.repository.MemberRepository;
 
 @SpringBootTest
 @ExtendWith({RestDocumentationExtension.class})
@@ -90,8 +83,7 @@ class AuthControllerTest {
     // then
     result
       .andDo(print())
-      .andExpect(status().is3xxRedirection())
-      .andExpect(redirectedUrl("/"))
+      .andExpect(status().isOk())
       .andDo(
         document(
           "login",

--- a/src/test/java/gdsc/konkuk/platformcore/controller/email/EmailControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/email/EmailControllerTest.java
@@ -11,10 +11,19 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gdsc.konkuk.platformcore.annotation.CustomMockUser;
+import gdsc.konkuk.platformcore.annotation.RestDocsTest;
+import gdsc.konkuk.platformcore.application.email.EmailService;
 import gdsc.konkuk.platformcore.application.email.EmailTaskFacade;
+import gdsc.konkuk.platformcore.controller.email.dto.EmailSendRequest;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import java.time.LocalDateTime;
 import java.util.List;
-
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,17 +38,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gdsc.konkuk.platformcore.annotation.CustomMockUser;
-import gdsc.konkuk.platformcore.annotation.RestDocsTest;
-import gdsc.konkuk.platformcore.application.email.EmailService;
-import gdsc.konkuk.platformcore.controller.email.dto.EmailSendRequest;
-import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
-import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
-import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 
 @RestDocsTest
 @SpringBootTest
@@ -74,7 +72,7 @@ class EmailControllerTest {
     EmailSendRequest request = EmailSendRequest.builder()
       .subject("예시 이메일 제목")
       .content("Html 문자열")
-      .receivers(List.of("ex1@gmail.com", "ex2@naver.com"))
+      .receivers(Set.of("ex1@gmail.com", "ex2@naver.com"))
       .sendAt(LocalDateTime.of(2024, 7, 20, 12, 30))
       .build();
     EmailDetails emailDetails = request.toEmailDetails();
@@ -120,7 +118,7 @@ class EmailControllerTest {
     EmailSendRequest request = EmailSendRequest.builder()
       .subject("예시 이메일 제목 수정")
       .content("Html 문자열")
-      .receivers(List.of("update@gmail.com", "update2@gmail.com", "update3@gmail.com"))
+      .receivers(Set.of("update@gmail.com", "update2@gmail.com", "update3@gmail.com"))
       .sendAt(LocalDateTime.of(2024,7,20,12,30))
       .build();
 
@@ -156,7 +154,7 @@ class EmailControllerTest {
   void should_success_when_get_all_task() throws Exception {
     //given
     EmailDetails emailDetails = new EmailDetails("예시 이메일 제목", "Html 문자열");
-    EmailReceivers emailReceivers = new EmailReceivers(List.of("example1@gmail.com", "example2@gmail.com", "example3@gmail.com"));
+    EmailReceivers emailReceivers = new EmailReceivers(Set.of("example1@gmail.com", "example2@gmail.com", "example3@gmail.com"));
     EmailTask emailTask = new EmailTask(1L, emailDetails, emailReceivers, LocalDateTime.of(2024, 7, 20, 12, 30));
 
     //when
@@ -196,7 +194,7 @@ class EmailControllerTest {
   void should_success_when_get_specific_task() throws Exception {
     //given
     EmailDetails emailDetails = new EmailDetails("예시 이메일 제목", "Html 문자열");
-    EmailReceivers emailReceivers = new EmailReceivers(List.of("example@gmail.com", "example@naver.com"));
+    EmailReceivers emailReceivers = new EmailReceivers(Set.of("example@gmail.com", "example@naver.com"));
     EmailTask emailTask = new EmailTask(1L, emailDetails, emailReceivers, LocalDateTime.of(2024, 7, 20, 12, 30));
 
     //when

--- a/src/test/java/gdsc/konkuk/platformcore/controller/event/EventControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/event/EventControllerTest.java
@@ -1,14 +1,32 @@
 package gdsc.konkuk.platformcore.controller.event;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gdsc.konkuk.platformcore.application.event.EventBrief;
 import gdsc.konkuk.platformcore.application.event.EventService;
-
 import gdsc.konkuk.platformcore.domain.event.entity.Event;
 import gdsc.konkuk.platformcore.domain.event.entity.Retrospect;
 import java.net.URL;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,28 +46,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.time.LocalDateTime;
 import org.springframework.web.multipart.MultipartFile;
-
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.MockitoAnnotations.openMocks;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @ExtendWith({RestDocumentationExtension.class})

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -11,9 +11,17 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gdsc.konkuk.platformcore.annotation.CustomMockUser;
 import gdsc.konkuk.platformcore.application.attendance.AttendanceInfo;
 import gdsc.konkuk.platformcore.application.member.MemberAttendanceInfo;
+import gdsc.konkuk.platformcore.application.member.MemberService;
+import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
+import gdsc.konkuk.platformcore.domain.member.entity.Member;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,17 +37,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gdsc.konkuk.platformcore.annotation.CustomMockUser;
-import gdsc.konkuk.platformcore.application.member.MemberService;
-import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
-import gdsc.konkuk.platformcore.domain.member.entity.Member;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @SpringBootTest
 @ExtendWith({RestDocumentationExtension.class})

--- a/src/test/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTaskTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTaskTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +20,14 @@ class EmailTaskTest {
               .subject("예시 이메일 제목")
               .content("Html 문자열")
               .build())
-          .receivers(new EmailReceivers(List.of("example@gmail.com", "example3@gmail.com")))
+          .receivers(new EmailReceivers(Set.of("example@gmail.com", "example3@gmail.com")))
           .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
           .build();
-      EmailReceivers newReceivers = new EmailReceivers(List.of("aaa@gmail.com", "bbb@gmail.com", "ccc@gmail.com"));
+      EmailReceivers newReceivers = new EmailReceivers(
+          Set.of("aaa@gmail.com", "bbb@gmail.com", "ccc@gmail.com"));
       //when
 
-      emailTask.changeEmailReceivers(newReceivers);
+      emailTask.changeEmailReceivers(newReceivers.getReceivers());
 
       //then
       assertEquals(newReceivers, emailTask.getEmailReceivers());
@@ -38,7 +40,7 @@ class EmailTaskTest {
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
-            .receivers(new EmailReceivers(List.of()))
+            .receivers(new EmailReceivers(Set.of()))
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
 
@@ -59,7 +61,7 @@ class EmailTaskTest {
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
-            .receivers(new EmailReceivers(List.of()))
+            .receivers(new EmailReceivers(Set.of()))
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
 
@@ -68,5 +70,41 @@ class EmailTaskTest {
 
     // then
     assertTrue(emailTask.isSent());
+  }
+
+  @Test
+  @DisplayName("수정 전 전송대상 중 겹치는 대상 추출")
+  void should_success_when_get_overlapping_receivers() {
+    // given
+    EmailTask emailTask =
+        EmailTask.builder()
+            .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
+            .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
+            .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
+            .build();
+    Set<String> newEmailReceivers = Set.of("example2.com", "example3.com");
+    // when
+    List<String> expected = List.of("example2.com");
+    List<String> actual = emailTask.filterReceiversInPrevSet(newEmailReceivers);
+    // then
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  @DisplayName("수정된 전송 대상 중 이전과 겹치지 않는 대상 추출")
+  void should_success_when_get_receivers_not_in_prev_set() {
+    // given
+    EmailTask emailTask =
+        EmailTask.builder()
+            .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
+            .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
+            .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
+            .build();
+    Set<String> newEmailReceivers = Set.of("example2.com", "example3.com");
+    // when
+    List<String> expected = List.of("example3.com");
+    List<String> actual = emailTask.filterReceiversNotInPrevSet(newEmailReceivers);
+    // then
+    assertEquals(actual, expected);
   }
 }

--- a/src/test/java/gdsc/konkuk/platformcore/external/discord/DiscordClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/discord/DiscordClientTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailClientErrorCode;
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
 import java.net.URI;
@@ -17,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
-
 
 @ExtendWith(MockitoExtension.class)
 class DiscordClientTest {

--- a/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
@@ -6,9 +6,10 @@ import static org.mockito.MockitoAnnotations.*;
 
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
+import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
 import java.time.LocalDateTime;
-import java.util.List;
-
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,9 +17,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.springframework.mail.MailParseException;
 import org.springframework.mail.javamail.JavaMailSender;
-
-import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
-import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
 
 class EmailClientTest {
 
@@ -40,7 +38,7 @@ class EmailClientTest {
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
-            .receivers(new EmailReceivers(List.of("aaa@gmail.com")))
+            .receivers(new EmailReceivers(Set.of("aaa@gmail.com")))
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
     //when


### PR DESCRIPTION
### 작업 내용

**문제점**
![Screenshot 2024-08-11 at 7 59 54 PM](https://github.com/user-attachments/assets/d7ad993f-1da7-49db-8def-569825a36d8f)


- ElementCollection으로 설정한 수신자리스트를 **업데이트 할 시
DELETE 쿼리가 모든 수신자들에 대해서 실행됨**. 바뀌지 않은 수신자도 새로 Insert하는 것 확인.

**해결방안**

![Screenshot 2024-08-11 at 8 01 37 PM](https://github.com/user-attachments/assets/8b76c5a8-d919-4d16-aaf8-d2c2d6a1ec79)

- 기존 `List<String>` 타입이었던 수신자 리스트를 `Set`자료구조로 변경, **수신자 업데이트 시 기존의 저장값들과
비교하여 기존의 값들은 그대로 사용, 새로운 값들만 Set에 추가하는 방식으로 변경**