### PR TITLE
Feat: include receiver name into mail registration

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
@@ -5,11 +5,13 @@ import static gdsc.konkuk.platformcore.application.email.EmailServiceHelper.find
 import gdsc.konkuk.platformcore.application.email.exceptions.EmailAlreadyProcessedException;
 import gdsc.konkuk.platformcore.application.email.exceptions.EmailErrorCode;
 import gdsc.konkuk.platformcore.controller.email.dtos.EmailSendRequest;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -48,7 +50,8 @@ public class EmailService {
     task.changeEmailDetails(request.toEmailDetails());
     task.changeSendAt(request.getSendAt());
 
-    Set<String> updatedReceivers = mergeReceivers(task, request.getReceivers());
+    Set<EmailReceiver> newReceivers = request.toEmailReceivers();
+    Set<EmailReceiver> updatedReceivers = mergeReceivers(task, newReceivers);
     task.changeEmailReceivers(updatedReceivers);
     return task;
   }
@@ -71,10 +74,10 @@ public class EmailService {
     }
   }
 
-  private Set<String> mergeReceivers(EmailTask emailTask, Set<String> updatedReceivers) {
-    List<String> receiversInPrevSet = emailTask.filterReceiversInPrevSet(updatedReceivers);
-    List<String> receiversInNewSet = emailTask.filterReceiversNotInPrevSet(updatedReceivers);
-    Set<String> mergedReceiver = new HashSet<>(receiversInPrevSet);
+  private Set<EmailReceiver> mergeReceivers(EmailTask emailTask, Set<EmailReceiver> updatedReceivers) {
+    List<EmailReceiver> receiversInPrevSet = emailTask.filterReceiversInPrevSet(updatedReceivers);
+    List<EmailReceiver> receiversInNewSet = emailTask.filterReceiversNotInPrevSet(updatedReceivers);
+    Set<EmailReceiver> mergedReceiver = new HashSet<>(receiversInPrevSet);
     mergedReceiver.addAll(receiversInNewSet);
     return mergedReceiver;
   }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/EmailReceiverInfo.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/EmailReceiverInfo.java
@@ -1,0 +1,37 @@
+package gdsc.konkuk.platformcore.controller.email.dtos;
+
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmailReceiverInfo {
+  @NotEmpty @Email
+  private String email;
+
+  @NotEmpty private String name;
+
+  @Builder
+  public EmailReceiverInfo(String email, String name) {
+    this.email = email;
+    this.name = name;
+  }
+
+  public static EmailReceiver toValueObject(EmailReceiverInfo info) {
+    return EmailReceiver.builder()
+      .email(info.getEmail())
+      .name(info.getName())
+      .build();
+  }
+
+  public static EmailReceiverInfo fromValueObject(EmailReceiver emailReceiver) {
+    return EmailReceiverInfo.builder()
+      .email(emailReceiver.getEmail())
+      .name(emailReceiver.getName())
+      .build();
+  }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/EmailSendRequest.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/EmailSendRequest.java
@@ -1,13 +1,14 @@
 package gdsc.konkuk.platformcore.controller.email.dtos;
 
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,21 +21,21 @@ public class EmailSendRequest {
   @NotEmpty
   private String content;
   @NotNull
-  private Set<@Email String> receivers;
+  private Set<EmailReceiverInfo> receiverInfos;
   @NotNull
   private LocalDateTime sendAt;
 
   @Builder
-  public EmailSendRequest(String subject, String content, Set<String> receivers, LocalDateTime sendAt) {
+  public EmailSendRequest(String subject, String content, Set<EmailReceiverInfo> receiverInfos, LocalDateTime sendAt) {
     this.subject = subject;
     this.content = content;
-    this.receivers = receivers;
+    this.receiverInfos = receiverInfos;
     this.sendAt = sendAt;
   }
 
   public static EmailTask toEntity(EmailSendRequest request) {
     EmailDetails details = new EmailDetails(request.getSubject(), request.getContent());
-    EmailReceivers receivers = new EmailReceivers(request.getReceivers());
+    EmailReceivers receivers = new EmailReceivers(request.toEmailReceivers());
     return EmailTask.builder()
       .emailDetails(details)
       .receivers(receivers)
@@ -46,7 +47,10 @@ public class EmailSendRequest {
     return new EmailDetails(subject, content);
   }
 
-  public EmailReceivers toEmailReceivers() {
-    return new EmailReceivers(receivers);
+  public Set<EmailReceiver> toEmailReceivers() {
+    return receiverInfos
+            .stream()
+            .map(EmailReceiverInfo::toValueObject)
+            .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/EmailTaskDetailsResponse.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/EmailTaskDetailsResponse.java
@@ -11,16 +11,17 @@ import lombok.Getter;
 public class EmailTaskDetailsResponse {
   private final String subject;
   private final String content;
-  private final List<String> receivers;
+  private final List<EmailReceiverInfo> receiverInfos;
   private final LocalDateTime sendAt;
 
   @Builder
   public EmailTaskDetailsResponse(EmailDetails emailDetails, EmailReceivers emailReceivers, LocalDateTime sendAt) {
     this.subject = emailDetails.getSubject();
     this.content = emailDetails.getContent();
-    this.receivers = emailReceivers
+    this.receiverInfos = emailReceivers
         .getReceivers()
         .stream()
+        .map(EmailReceiverInfo::fromValueObject)
         .toList();
     this.sendAt = sendAt;
   }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/SimpleEmailTaskResponse.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/dtos/SimpleEmailTaskResponse.java
@@ -1,6 +1,7 @@
 package gdsc.konkuk.platformcore.controller.email.dtos;
 
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -11,25 +12,26 @@ public class SimpleEmailTaskResponse {
 
   private final Long id;
   private final String subject;
-  private final String receiver;
+  private final EmailReceiverInfo receiverInfos;
   private final LocalDateTime sendAt;
   private final Boolean isSent;
 
   @Builder
-  public SimpleEmailTaskResponse(Long id, String subject, String receiver, LocalDateTime sendAt, boolean isSent) {
+  public SimpleEmailTaskResponse(Long id, String subject, EmailReceiverInfo receiverInfos, LocalDateTime sendAt, boolean isSent) {
     this.id = id;
     this.subject = subject;
-    this.receiver = receiver;
+    this.receiverInfos = receiverInfos;
     this.sendAt = sendAt;
     this.isSent = isSent;
   }
 
-  public static SimpleEmailTaskResponse of(EmailTask emailTask, String receiver) {
+  public static SimpleEmailTaskResponse of(EmailTask emailTask, EmailReceiver receiver) {
     EmailDetails emailDetails = emailTask.getEmailDetails();
+    EmailReceiverInfo receiverInfo = EmailReceiverInfo.fromValueObject(receiver);
     return SimpleEmailTaskResponse.builder()
         .id(emailTask.getId())
         .subject(emailDetails.getSubject())
-        .receiver(receiver)
+        .receiverInfos(receiverInfo)
         .sendAt(emailTask.getSendAt())
         .isSent(emailTask.isSent())
         .build();

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceiver.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceiver.java
@@ -1,0 +1,25 @@
+package gdsc.konkuk.platformcore.domain.email.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailReceiver {
+  @Column(name = "receiver_email")
+  private String email;
+
+  @Column(name = "receiver_name")
+  private String name;
+
+  @Builder
+  public EmailReceiver(String email, String name) {
+    this.email = email;
+    this.name = name;
+  }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceiver.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceiver.java
@@ -22,4 +22,17 @@ public class EmailReceiver {
     this.email = email;
     this.name = name;
   }
+
+  @Override
+  public int hashCode() {
+    return (this.email + this.name).hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EmailReceiver that = (EmailReceiver) o;
+    return email.equals(that.email) && name.equals(that.name);
+  }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
@@ -1,7 +1,6 @@
 package gdsc.konkuk.platformcore.domain.email.entity;
 
 import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.JoinColumn;
 import java.util.HashSet;
@@ -20,10 +19,9 @@ public class EmailReceivers {
 
   @ElementCollection
   @CollectionTable(name = "email_receivers", joinColumns = @JoinColumn(name = "task_id"))
-  @Column(name = "receiver_email")
-  Set<String> receivers = new HashSet<>();
+  Set<EmailReceiver> receivers = new HashSet<>();
 
-  public EmailReceivers(Set<String> receivers) {
+  public EmailReceivers(Set<EmailReceiver> receivers) {
     this.receivers.addAll(receivers);
   }
 
@@ -44,7 +42,7 @@ public class EmailReceivers {
     this.receivers.clear();
   }
 
-  public void insertAll(Set<String> set) {
+  public void insertAll(Set<EmailReceiver> set) {
     this.receivers.addAll(set);
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTask.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTask.java
@@ -50,7 +50,7 @@ public class EmailTask {
     emailDetails = newEmailDetails;
   }
 
-  public void changeEmailReceivers(final Set<String> set) {
+  public void changeEmailReceivers(final Set<EmailReceiver> set) {
     emailReceivers.removeAll();
     emailReceivers.insertAll(set);
   }
@@ -63,17 +63,17 @@ public class EmailTask {
     isSent = true;
   }
 
-  public List<String> filterReceiversInPrevSet(Set<String> set) {
+  public List<EmailReceiver> filterReceiversInPrevSet(Set<EmailReceiver> set) {
     return this.getEmailReceivers().getReceivers()
         .stream()
         .filter(set::contains)
         .toList();
   }
 
-  public List<String> filterReceiversNotInPrevSet(Set<String> set) {
+  public List<EmailReceiver> filterReceiversNotInPrevSet(Set<EmailReceiver> set) {
     return set
         .stream()
-        .filter((e) -> !emailReceivers.getReceivers().contains(e))
+        .filter((e) -> !this.emailReceivers.getReceivers().contains(e))
         .toList();
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/external/email/EmailClient.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/email/EmailClient.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.external.email;
 
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
@@ -26,15 +27,16 @@ public class EmailClient {
 
   public void sendEmailToReceivers(EmailTask email) {
     EmailDetails emailDetails = email.getEmailDetails();
-    Set<String> receivers = email.getEmailReceivers().getReceivers();
+    Set<EmailReceiver> receivers = email.getEmailReceivers().getReceivers();
     receivers.forEach(receiver -> sendEmail(receiver, emailDetails));
   }
 
-  private void sendEmail(String to, EmailDetails emailDetails) {
+  private void sendEmail(EmailReceiver to, EmailDetails emailDetails) {
     try {
       log.info("Sending email to {}", to);
+      // TODO: message 내용에 receiver 이름 반영
       MimeMessage message =
-          convertToHTMLMimeMessage(to, emailDetails.getSubject(), emailDetails.getContent());
+          convertToHTMLMimeMessage(to.getEmail(), emailDetails.getSubject(), emailDetails.getContent());
       javaMailSender.send(message);
     } catch (MailParseException | MessagingException e) {
       throw EmailSendingException.of(EmailClientErrorCode.MAIL_PARSING_ERROR, e.getMessage());

--- a/src/main/java/gdsc/konkuk/platformcore/external/email/EmailClient.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/email/EmailClient.java
@@ -34,9 +34,9 @@ public class EmailClient {
   private void sendEmail(EmailReceiver to, EmailDetails emailDetails) {
     try {
       log.info("Sending email to {}", to);
-      // TODO: message 내용에 receiver 이름 반영
+      String emailContent = emailDetails.getContent().replaceAll("\\{이름}", to.getName());
       MimeMessage message =
-          convertToHTMLMimeMessage(to.getEmail(), emailDetails.getSubject(), emailDetails.getContent());
+          convertToHTMLMimeMessage(to.getEmail(), emailDetails.getSubject(), emailContent);
       javaMailSender.send(message);
     } catch (MailParseException | MessagingException e) {
       throw EmailSendingException.of(EmailClientErrorCode.MAIL_PARSING_ERROR, e.getMessage());

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
@@ -11,6 +11,8 @@ public class PlatformConstants {
   public static final String LOGIN_NAME = "id";
   public static final String API_PREFIX = "/api/v1";
 
+  public static final String EMAIL_RECEIVER_NAME_REGEXP = "\\{이름}";
+
   public static final String DISCORD_ERROR_TITLE = "\uD83E\uDDE8 치명적인 서버 에러 발생!";
   public static final String DISCORD_ERROR_DESCRIPTION =
       "\uD83C\uDD98 서버에서 치명적인 에러가 발생했습니다. 빠르게 확인해주세요. \uD83C\uDD98";

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailIntegrationTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailIntegrationTest.java
@@ -9,7 +9,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.util.AssertionErrors.assertNotNull;
+import static org.springframework.test.util.AssertionErrors.fail;
 
+import gdsc.konkuk.platformcore.application.email.exceptions.EmailAlreadyProcessedException;
 import gdsc.konkuk.platformcore.controller.email.dtos.EmailSendRequest;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
@@ -185,14 +187,18 @@ class EmailIntegrationTest {
             .receivers(Set.of("example1.com", "example2.com"))
             .sendAt(LocalDateTime.now().plusSeconds(1L))
             .build();
+
     //when
     EmailTask scheduledTask = emailTaskFacade.register(emailRequest);
-
     sleep(2000);
+
     //then
-    assertThrows(
-        TaskNotFoundException.class,
-        () -> emailTaskFacade.cancel(scheduledTask.getId()));
+    try{
+      emailTaskFacade.cancel(scheduledTask.getId());
+      fail("`TaskNotFoundException` or `EmailAlreadyProcessedException` should be thrown");
+    }catch(TaskNotFoundException | EmailAlreadyProcessedException e){
+      // pass
+    }
   }
 
   @Test

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceHelperTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceHelperTest.java
@@ -6,6 +6,7 @@ import static org.mockito.MockitoAnnotations.*;
 
 import gdsc.konkuk.platformcore.application.email.exceptions.EmailNotFoundException;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
@@ -25,7 +26,10 @@ class EmailServiceHelperTest {
       EmailTask.builder()
           .id(1L)
           .emailDetails(new EmailDetails("subject", "content"))
-          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(
+              Set.of(
+                  EmailReceiver.builder().email("example1.com").name("guest1").build(),
+                  EmailReceiver.builder().email("example2.com").name("guest2").build())))
           .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
           .build();
 

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailTaskFacadeTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailTaskFacadeTest.java
@@ -4,8 +4,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import gdsc.konkuk.platformcore.controller.email.dtos.EmailReceiverInfo;
 import gdsc.konkuk.platformcore.controller.email.dtos.EmailSendRequest;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.global.scheduler.TaskScheduler;
@@ -31,7 +33,10 @@ class EmailTaskFacadeTest {
       EmailTask.builder()
           .id(1L)
           .emailDetails(new EmailDetails("subject", "content"))
-          .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
+          .receivers(new EmailReceivers(
+              Set.of(
+                  EmailReceiver.builder().email("example1.com").name("guest1").build(),
+                  EmailReceiver.builder().email("example2.com").name("guest2").build())))
           .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
           .build();
 
@@ -49,11 +54,16 @@ class EmailTaskFacadeTest {
         EmailSendRequest.builder()
             .subject("subject")
             .content("content")
-            .receivers(Set.of("example1.com", "example2.com"))
+            .receiverInfos(
+                Set.of(
+                    EmailReceiverInfo.builder().email("example1.com").name("guest1").build(),
+                    EmailReceiverInfo.builder().email("example2.com").name("guest2").build()))
             .sendAt(LocalDateTime.of(2021, 1, 1, 1, 1))
             .build();
+
     //when
     when(emailService.update(1L, emailRequest)).thenReturn(mock1);
+
     //then
     subject.update(1L, emailRequest);
     verify(emailTaskScheduler).cancelTask("1");
@@ -64,6 +74,7 @@ class EmailTaskFacadeTest {
   void should_success_when_cancel_task() {
     //given
     Long emailId = 1L;
+
     //when
     subject.cancel(1L);
 

--- a/src/test/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTaskTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTaskTest.java
@@ -20,13 +20,19 @@ class EmailTaskTest {
               .subject("예시 이메일 제목")
               .content("Html 문자열")
               .build())
-          .receivers(new EmailReceivers(Set.of("example@gmail.com", "example3@gmail.com")))
+          .receivers(new EmailReceivers(
+              Set.of(
+                  EmailReceiver.builder().email("example@gmail.com").name("guest1").build(),
+                  EmailReceiver.builder().email("example3@gmail.com").name("guest2").build())))
           .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
           .build();
       EmailReceivers newReceivers = new EmailReceivers(
-          Set.of("aaa@gmail.com", "bbb@gmail.com", "ccc@gmail.com"));
-      //when
+          Set.of(
+              EmailReceiver.builder().email("aaa@gmail.com").name("guest a").build(),
+              EmailReceiver.builder().email("bbb@gmail.com").name("guest b").build(),
+              EmailReceiver.builder().email("ccc@gmail.com").name("guest c").build()));
 
+      //when
       emailTask.changeEmailReceivers(newReceivers.getReceivers());
 
       //then
@@ -79,13 +85,20 @@ class EmailTaskTest {
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
-            .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
+            .receivers(new EmailReceivers(
+                Set.of(
+                    EmailReceiver.builder().email("example1.com").name("guest1").build(),
+                    EmailReceiver.builder().email("example2.com").name("guest2").build())))
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
-    Set<String> newEmailReceivers = Set.of("example2.com", "example3.com");
+    Set<EmailReceiver> newEmailReceivers = Set.of(
+        EmailReceiver.builder().email("example2.com").name("guest2").build(),
+        EmailReceiver.builder().email("example3.com").name("guest3").build());
+
     // when
-    List<String> expected = List.of("example2.com");
-    List<String> actual = emailTask.filterReceiversInPrevSet(newEmailReceivers);
+    List<EmailReceiver> expected = List.of(EmailReceiver.builder().email("example2.com").name("guest2").build());
+    List<EmailReceiver> actual = emailTask.filterReceiversInPrevSet(newEmailReceivers);
+
     // then
     assertEquals(actual, expected);
   }
@@ -97,13 +110,21 @@ class EmailTaskTest {
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
-            .receivers(new EmailReceivers(Set.of("example1.com", "example2.com")))
+            .receivers(new EmailReceivers(
+                Set.of(
+                  EmailReceiver.builder().email("example1.com").name("guest1").build(),
+                  EmailReceiver.builder().email("example2.com").name("guest2").build())))
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
-    Set<String> newEmailReceivers = Set.of("example2.com", "example3.com");
+    Set<EmailReceiver> newEmailReceivers = Set.of(
+        EmailReceiver.builder().email("example2.com").name("guest2").build(),
+        EmailReceiver.builder().email("example3.com").name("guest3").build());
+
     // when
-    List<String> expected = List.of("example3.com");
-    List<String> actual = emailTask.filterReceiversNotInPrevSet(newEmailReceivers);
+    List<EmailReceiver> expected = List.of(
+        EmailReceiver.builder().email("example3.com").name("guest3").build());
+    List<EmailReceiver> actual = emailTask.filterReceiversNotInPrevSet(newEmailReceivers);
+
     // then
     assertEquals(actual, expected);
   }

--- a/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
@@ -1,6 +1,7 @@
 package gdsc.konkuk.platformcore.external.email;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.*;
 
@@ -9,6 +10,7 @@ import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
+import jakarta.mail.internet.MimeMessage;
 import java.time.LocalDateTime;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,13 +31,13 @@ class EmailClientTest {
   @BeforeEach
   void setUp() {
     openMocks(this);
-    emailClient = new EmailClient(javaMailSender);
+    emailClient = spy(new EmailClient(javaMailSender));
   }
 
   @Test
   @DisplayName("이메일의 내용 및 제목 형식 오류 발생")
   void should_fail_when_email_parsing() {
-     //given
+     // given
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
@@ -44,11 +46,52 @@ class EmailClientTest {
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
 
-    //when
+    // when
     when(javaMailSender.createMimeMessage()).thenThrow(new MailParseException("error"));
     Executable result = () -> emailClient.sendEmailToReceivers(emailTask);
 
-     //then
+     // then
     assertThrowsExactly(EmailSendingException.class, result);
+  }
+
+  @Test
+  @DisplayName("이메일 내용 중 {이름}은 수신자의 이름으로 치환되어야 함")
+  void should_replace_to_receiver_name_when_name_token() {
+    // given
+    EmailTask emailTask =
+        EmailTask.builder()
+            .emailDetails(EmailDetails.builder()
+                .subject("예시 이메일 제목")
+                .content("안녕하세요, {이름}님 합격을 축하드립니다!. {이름}님과 함께할 수 있어 기쁩니다.")
+                .build())
+            .receivers(new EmailReceivers(
+                Set.of(EmailReceiver.builder().email("ex@ex.com").name("guest1").build())))
+            .sendAt(LocalDateTime.of(2024, 10, 10, 10, 10))
+            .build();
+    MimeMessage mockMimeMessage = mock(MimeMessage.class);
+    given(javaMailSender.createMimeMessage()).willReturn(mockMimeMessage);
+    given(emailClient.replaceNameToken(anyString(),anyString())).willReturn("");
+
+    // when
+    emailClient.sendEmailToReceivers(emailTask);
+
+    // then
+    verify(emailClient).replaceNameToken(
+      eq("안녕하세요, {이름}님 합격을 축하드립니다!. {이름}님과 함께할 수 있어 기쁩니다."),
+      eq("guest1"));
+  }
+
+  @Test
+  @DisplayName("이메일 이름 토큰({이름}) 치환 테스트")
+  void should_success_when_replace_name_token() {
+    // given
+    String content = "안녕하세요, {이름}님 합격을 축하드립니다!. {이름}님과 함께할 수 있어 기쁩니다.";
+    String name = "guest1";
+
+    // when
+    String result = emailClient.replaceNameToken(content, name);
+
+    // then
+    assertEquals("안녕하세요, guest1님 합격을 축하드립니다!. guest1님과 함께할 수 있어 기쁩니다.", result);
   }
 }

--- a/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.*;
 
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetails;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceivers;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
@@ -38,9 +39,11 @@ class EmailClientTest {
     EmailTask emailTask =
         EmailTask.builder()
             .emailDetails(EmailDetails.builder().subject("예시 이메일 제목").content("Html 문자열").build())
-            .receivers(new EmailReceivers(Set.of("aaa@gmail.com")))
+            .receivers(new EmailReceivers(
+                Set.of(EmailReceiver.builder().email("aaa@gmail.com").name("guest1").build())))
             .sendAt(LocalDateTime.of(2021, 10, 10, 10, 10))
             .build();
+
     //when
     when(javaMailSender.createMimeMessage()).thenThrow(new MailParseException("error"));
     Executable result = () -> emailClient.sendEmailToReceivers(emailTask);


### PR DESCRIPTION
- 이메일 예약 중 `email` 값은 받아오지만, `name` 값이 request에 누락되어있던 문제 해결
- 이메일 내용 중 `{이름}`을 수신자의 이름으로 치환하도록 변경
- 이메일 통합테스트 중, 확률적으로 fail하던 테스트가 언제나 pass하도록 변경
- 이메일 테스트 중, windows OS에서 허용되지 않는 restdocs id를 windows OS 호환되도록 수정