### PR TITLE
Feat : member register

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/MemberErrorCode.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/MemberErrorCode.java
@@ -10,6 +10,8 @@ public enum MemberErrorCode implements CustomErrorCode {
   INVALID_USER_INFO("사용자 정보가 올바르지 않습니다. 다시 입력해주세요", "[ERROR] : 사용자 정보가 올바르지 않음"),
   DEACTIVATED_USER("비활성화된 사용자입니다. 다시 확인해주세요", "[ERROR] : 비활성화된 사용자"),
   USER_ALREADY_EXISTS("이미 존재하는 사용자입니다.", "[ERROR] : 이미 존재하는 사용자"),
+  USER_PASSWORD_INVALID("비밀번호가 일치하지 않습니다. 다시 입력해주세요", "[ERROR] : 비밀번호가 일치하지 않음"),
+  USER_NOT_ALLOWED("권한이 없습니다. 다시 확인해주세요", "[ERROR] : 권한이 없음"),
   USER_ALREADY_DELETED("이미 삭제된 사용자입니다.", "[ERROR] : 이미 삭제된 사용자");
 
   private final String message;

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserNotAllowedException.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserNotAllowedException.java
@@ -1,0 +1,14 @@
+package gdsc.konkuk.platformcore.application.member.exceptions;
+
+import gdsc.konkuk.platformcore.global.exceptions.BusinessException;
+import gdsc.konkuk.platformcore.global.exceptions.CustomErrorCode;
+
+public class UserNotAllowedException extends BusinessException {
+  protected UserNotAllowedException(CustomErrorCode errorCode, String logMessage) {
+    super(errorCode, logMessage);
+  }
+
+  public static UserNotAllowedException of(CustomErrorCode errorCode) {
+    return new UserNotAllowedException(errorCode, errorCode.getMessage());
+  }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserPasswordInvalidException.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserPasswordInvalidException.java
@@ -1,0 +1,14 @@
+package gdsc.konkuk.platformcore.application.member.exceptions;
+
+import gdsc.konkuk.platformcore.global.exceptions.BusinessException;
+import gdsc.konkuk.platformcore.global.exceptions.CustomErrorCode;
+
+public class UserPasswordInvalidException extends BusinessException {
+  protected UserPasswordInvalidException(CustomErrorCode errorCode, String logMessage) {
+    super(errorCode, logMessage);
+  }
+
+  public static UserPasswordInvalidException of(CustomErrorCode errorCode) {
+    return new UserPasswordInvalidException(errorCode, errorCode.getMessage());
+  }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
@@ -59,11 +59,11 @@ public class AttendanceController {
       attendanceService.attend(oidcUser.getEmail(), attendanceId, qrUuid);
       HttpHeaders headers = new HttpHeaders();
       headers.add("Location", "/success");
-      return new ResponseEntity<>(headers, valueOf(HttpStatusCode.MOVED_PERMANENTLY));
+      return new ResponseEntity<>(headers, valueOf(HttpStatusCode.TEMPORARY_REDIRECT));
     }catch(Exception e) {
       HttpHeaders headers = new HttpHeaders();
       headers.add("Location", "/fail");
-      return new ResponseEntity<>(headers, valueOf(HttpStatusCode.MOVED_PERMANENTLY));
+      return new ResponseEntity<>(headers, valueOf(HttpStatusCode.TEMPORARY_REDIRECT));
     }
   }
 

--- a/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
@@ -58,11 +58,11 @@ public class AttendanceController {
     try{
       attendanceService.attend(oidcUser.getEmail(), attendanceId, qrUuid);
       HttpHeaders headers = new HttpHeaders();
-      headers.add("Location", "/success");
+      headers.add("Location", "/admin/success");
       return new ResponseEntity<>(headers, valueOf(HttpStatusCode.TEMPORARY_REDIRECT));
     }catch(Exception e) {
       HttpHeaders headers = new HttpHeaders();
-      headers.add("Location", "/fail");
+      headers.add("Location", "/admin/fail");
       return new ResponseEntity<>(headers, valueOf(HttpStatusCode.TEMPORARY_REDIRECT));
     }
   }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
@@ -58,11 +58,11 @@ public class AttendanceController {
     try{
       attendanceService.attend(oidcUser.getEmail(), attendanceId, qrUuid);
       HttpHeaders headers = new HttpHeaders();
-      headers.add("Location", "/admin/success");
+      headers.add("Location", "/admin/attendance-return/success");
       return new ResponseEntity<>(headers, valueOf(HttpStatusCode.TEMPORARY_REDIRECT));
     }catch(Exception e) {
       HttpHeaders headers = new HttpHeaders();
-      headers.add("Location", "/admin/fail");
+      headers.add("Location", "/admin/attendance-return/fail");
       return new ResponseEntity<>(headers, valueOf(HttpStatusCode.TEMPORARY_REDIRECT));
     }
   }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
@@ -3,6 +3,7 @@ package gdsc.konkuk.platformcore.controller.member;
 import gdsc.konkuk.platformcore.application.member.dtos.MemberAttendances;
 import gdsc.konkuk.platformcore.controller.member.dtos.AttendanceUpdateRequest;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberRegisterRequest;
+import gdsc.konkuk.platformcore.controller.member.dtos.PasswordChangeRequest;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
@@ -44,6 +45,14 @@ public class MemberController {
     Member registeredMember = memberService.register(registerRequest);
     return ResponseEntity.created(getCreatedURI(registeredMember.getId()))
         .body(SuccessResponse.messageOnly());
+  }
+
+  @PostMapping("/{member-id}/password")
+  public ResponseEntity<SuccessResponse> changePassword(
+      @PathVariable("member-id") String memberId,
+      @RequestBody @Valid PasswordChangeRequest passwordChangeRequest) {
+    memberService.changePassword(memberId, passwordChangeRequest.getPassword());
+    return ResponseEntity.ok(SuccessResponse.messageOnly());
   }
 
   @DeleteMapping()

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberRegisterRequest.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberRegisterRequest.java
@@ -13,8 +13,6 @@ public class MemberRegisterRequest {
   @NotEmpty
   private String memberId;
   @NotEmpty
-  private String password;
-  @NotEmpty
   private String name;
   @NotEmpty
   private String email;
@@ -28,7 +26,7 @@ public class MemberRegisterRequest {
   public static Member toEntity(MemberRegisterRequest request) {
     return Member.builder()
       .memberId(request.getMemberId())
-      .password(request.getPassword())
+      .password("") // `PasswordEncoder`로 생성할 수 없는 문자열 (로그인 불가해야 함)
       .name(request.getName())
       .email(request.getEmail())
       .department(request.getDepartment())

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/PasswordChangeRequest.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/PasswordChangeRequest.java
@@ -1,0 +1,18 @@
+package gdsc.konkuk.platformcore.controller.member.dtos;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordChangeRequest {
+  @NotEmpty
+  private String password;
+}

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
@@ -74,6 +74,14 @@ public class Member {
     softDeletedAt = LocalDateTime.now().plusMonths(SOFT_DELETE_RETENTION_MONTHS);
   }
 
+  public boolean isPasswordCorrect(String password) {
+    return this.password.equals(password);
+  }
+
+  public void updatePassword(String password) {
+    this.password = password;
+  }
+
   public Boolean isMemberDeleted() {
     return isDeleted;
   }

--- a/src/main/java/gdsc/konkuk/platformcore/global/configs/SecurityConfig.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/configs/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/login")
                     .permitAll()
+                    .requestMatchers(HttpMethod.POST, apiPath("/members/{member-id}/password"))
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, apiPath("/members/check-login"))
                     .authenticated()
                     .anyRequest()

--- a/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
@@ -52,7 +52,6 @@ class MemberServiceTest {
     Member memberToRegister = MemberFixture.builder().build().getFixture();
     given(memberRepository.findByMemberId(memberRegisterRequest.getMemberId())).willReturn(Optional.empty());
     given(memberRepository.save(any(Member.class))).willReturn(memberToRegister);
-    given(passwordEncoder.encode(memberRegisterRequest.getPassword())).willReturn(memberToRegister.getPassword());
 
     // when
     Member actual = subject.register(memberRegisterRequest);

--- a/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
@@ -165,7 +165,7 @@ class AttendanceControllerTest {
     // then
     result
         .andDo(print())
-        .andExpect(status().isMovedPermanently())
+        .andExpect(status().isTemporaryRedirect())
         .andDo(
             document(
                 "attend",

--- a/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
@@ -165,7 +165,7 @@ class AttendanceControllerTest {
     // then
     result
         .andDo(print())
-        .andExpect(status().isOk())
+        .andExpect(status().isMovedPermanently())
         .andDo(
             document(
                 "attend",
@@ -177,10 +177,7 @@ class AttendanceControllerTest {
                         .tag("attendance")
                         .pathParameters(parameterWithName("attendanceId").description("출석 ID"))
                         .queryParameters(parameterWithName("qrUuid").description("QR 코드 UUID"))
-                        .responseFields(
-                            fieldWithPath("success").description("성공 여부"),
-                            fieldWithPath("message").description("메시지"),
-                            fieldWithPath("data").description("null"))
+                        .responseHeaders(headerWithName("Location").description("출석 결과 페이지"))
                         .build())));
   }
 

--- a/src/test/java/gdsc/konkuk/platformcore/controller/auth/AuthControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/auth/AuthControllerTest.java
@@ -59,7 +59,7 @@ class AuthControllerTest {
   void loginSuccess() throws Exception {
     // given
     Member memberToLogin = MemberFixture.builder()
-        .memberId("202400000").password("$2a$10$d7DjseDroHsRGVGR1zDUL.q7uwAQ2aH4nHM1JiQ1OFV.D0qUTl7w.").build().getFixture();
+        .memberId("202400000").password(passwordEncoder.encode("password")).build().getFixture();
     given(memberRepository.findByMemberId(memberToLogin.getMemberId()))
       .willReturn(Optional.of(memberToLogin));
 

--- a/src/test/java/gdsc/konkuk/platformcore/fixture/member/MemberFixture.java
+++ b/src/test/java/gdsc/konkuk/platformcore/fixture/member/MemberFixture.java
@@ -16,7 +16,7 @@ public class MemberFixture {
     this.fixture = Member.builder()
       .id(getDefault(id, 0L))
       .memberId(getDefault(memberId, "202400000"))
-      .password(getDefault(password, "$2a$10$d7DjseDroHsRGVGR1zDUL.q7uwAQ2aH4nHM1JiQ1OFV.D0qUTl7w." /* == encoded "password" */))
+      .password(getDefault(password, "some_encoded_password"))
       .name(getDefault(name, "name"))
       .email(getDefault(email, "ex@gmail.com"))
       .department(getDefault(department, "department"))

--- a/src/test/java/gdsc/konkuk/platformcore/fixture/member/MemberRegisterRequestFixture.java
+++ b/src/test/java/gdsc/konkuk/platformcore/fixture/member/MemberRegisterRequestFixture.java
@@ -12,10 +12,9 @@ public class MemberRegisterRequestFixture {
   private final MemberRegisterRequest fixture;
 
   @Builder
-  public MemberRegisterRequestFixture(String memberId, String password, String email, String name, String department, String batch, MemberRole role) {
+  public MemberRegisterRequestFixture(String memberId, String email, String name, String department, String batch, MemberRole role) {
     this.fixture = MemberRegisterRequest.builder()
       .memberId(getDefault(memberId, "2024000000"))
-      .password(getDefault(password, "password"))
       .email(getDefault(email, "ex@gmail.com"))
       .name(getDefault(name, "name"))
       .department(getDefault(department, "department"))

--- a/src/test/java/gdsc/konkuk/platformcore/fixture/member/PasswordChangeRequestFixture.java
+++ b/src/test/java/gdsc/konkuk/platformcore/fixture/member/PasswordChangeRequestFixture.java
@@ -1,0 +1,17 @@
+package gdsc.konkuk.platformcore.fixture.member;
+
+import gdsc.konkuk.platformcore.controller.member.dtos.PasswordChangeRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PasswordChangeRequestFixture {
+  private final PasswordChangeRequest fixture;
+
+  @Builder
+  public PasswordChangeRequestFixture(String password) {
+    this.fixture = PasswordChangeRequest.builder()
+      .password(password)
+      .build();
+  }
+}


### PR DESCRIPTION
## 변경점

- QR 출성 성공/실패시 JSON data 전송 대신 별도 페이지로 re-direction
- 사용자 회원가입 기능
- `MemberFixture`가 dummy password가 아닌, 실제 `PasswordEncoder`로 인코딩한 password를 사용하도록 수정

### 사용자 회원가입은 미완의 기능입니다!

 우리는 사전에 등록된 사용자만 회원가입에 성공하도록 제한해야 합니다. 따라서 DB에 저장된 `Member` 중 `Admin` 권한을 가진 사용자에 한해서 회원가입을 진행해야 합니다. 현 PR에서는, password가 초깃값(`""`)일 경우에 한해 **password를 변경 허용**하는 방향으로 회원가입을 진행합니다. 이 방법은 다음의 문제가 있습니다.

1. 사용자 본인 확인이 수행되지 않음 -- 누구든 `Admin` 계정을 처음으로 접속할 경우 사용자 본인 확인 없이 회원가입이 가능합니다.
2. 최초 1회 이후 회원정보(password) 변경이 불가능함. 사실 이 부분은 `회원정보 수정` 기능이 구현되어있지 않다고 생각할수도 있습니다.