### PR TITLE
[Feature/paginate email receivers] - 페이지네이션 추가

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
@@ -11,8 +11,10 @@ import gdsc.konkuk.platformcore.domain.email.repository.EmailTaskRepository;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,11 @@ public class EmailService {
 
   public List<EmailTask> getAllTaskAsList() {
     return emailTaskRepository.findAll();
+  }
+
+  public Page<EmailTask> getAllTaskWithPage(int pageNo) {
+    Pageable pageable = PageRequest.of(pageNo, 10);
+    return emailTaskRepository.findAll(pageable);
   }
 
   public EmailTask getTaskDetails(Long taskId) {

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/EmailController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/EmailController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,6 +33,14 @@ public class EmailController {
   @GetMapping
   public ResponseEntity<SuccessResponse> getAllEmailTask() {
     EmailTaskListResponse emailTasks = EmailTaskMapper.mapToEmailTaskListResponse(emailService.getAllTaskAsList());
+    return ResponseEntity.ok(SuccessResponse.of(emailTasks));
+  }
+
+  @GetMapping("/pages")
+  public ResponseEntity<SuccessResponse> getAllEmailTask(
+      @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo
+  ) {
+    EmailTaskListResponse emailTasks = EmailTaskMapper.mapToEmailTaskPageResponse(emailService.getAllTaskWithPage(pageNo));
     return ResponseEntity.ok(SuccessResponse.of(emailTasks));
   }
 

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/mapper/EmailTaskMapper.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/mapper/EmailTaskMapper.java
@@ -8,9 +8,14 @@ import gdsc.konkuk.platformcore.controller.email.dtos.SimpleEmailTaskResponse;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailTaskMapper {
+
+  public static EmailTaskListResponse mapToEmailTaskPageResponse(Page<EmailTask> emailTasks) {
+    return mapToEmailTaskListResponse(emailTasks.getContent());
+  }
 
   public static EmailTaskListResponse mapToEmailTaskListResponse(List<EmailTask> emailTasks) {
     List<SimpleEmailTaskResponse> simpleEmailTaskResponses =

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceivers.java
@@ -2,6 +2,7 @@ package gdsc.konkuk.platformcore.domain.email.entity;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import java.util.HashSet;
 import java.util.Objects;
@@ -11,13 +12,15 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailReceivers {
 
-  @ElementCollection
+  @BatchSize(size = 100)
+  @ElementCollection(fetch = FetchType.LAZY)
   @CollectionTable(name = "email_receivers", joinColumns = @JoinColumn(name = "task_id"))
   Set<EmailReceiver> receivers = new HashSet<>();
 

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/repository/EmailTaskRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/repository/EmailTaskRepository.java
@@ -13,8 +13,5 @@ public interface EmailTaskRepository extends JpaRepository<EmailTask, Long> {
   @Query("SELECT e FROM EmailTask e WHERE e.isSent = false")
   List<EmailTask> findAllWhereNotSent();
 
-  @Query("SELECT e FROM EmailTask e WHERE e.isSent = false")
-  List<EmailTask> findAll();
-
   Page<EmailTask> findAll(Pageable pageable);
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/repository/EmailTaskRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/repository/EmailTaskRepository.java
@@ -1,6 +1,8 @@
 package gdsc.konkuk.platformcore.domain.email.repository;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
@@ -10,4 +12,9 @@ public interface EmailTaskRepository extends JpaRepository<EmailTask, Long> {
 
   @Query("SELECT e FROM EmailTask e WHERE e.isSent = false")
   List<EmailTask> findAllWhereNotSent();
+
+  @Query("SELECT e FROM EmailTask e WHERE e.isSent = false")
+  List<EmailTask> findAll();
+
+  Page<EmailTask> findAll(Pageable pageable);
 }


### PR DESCRIPTION
### 작업내역
- **페이지네이션 가능한 endpoint추가**

현재 클라이언트개발 미완으로 적용하지않았습니다. 임시 Endpoint : `api/v1/emails/page` 로 만들었어요

- **EmailTask N+1해결**

기존 코드에서 CollectionTable에 대한 접근 시 N+1문제가 발생했습니다.
![Screenshot 2024-10-02 at 3 25 50 AM](https://github.com/user-attachments/assets/6bed98c9-73bb-47d9-8c3c-bab1a37d5581)

이에 `EmailReceivers`에 배치사이즈를 적용하였습니다.

![Screenshot 2024-10-02 at 3 06 27 AM](https://github.com/user-attachments/assets/515c5935-fdf8-4388-8181-758be30f053a)

현재는 위와 같이 쿼리가 생성됩니다.

### 중요사항

페이지네이션 적용과정에서 몇가지 고려할 점이 있습니다.
1. task갯수에 대해서 페이지네이션인지
2. receivers에 대해서인지

현재는 task의 갯수에 대해서 페이지네이션을 진행합니다. **하지만 전송하는 대상이 많다면 여전히 화면에서 보여질 데이터가 많아집니다.**
