### PR TITLE
chore : awslogs multline pattern 설정

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -41,6 +41,7 @@ services:
         awslogs-region: ${AWS_REGION}
         awslogs-group: ${AWS_LOG_GROUP}
         awslogs-stream: spring
+        awslogs-datetime-format: "^%Y-%m-%dT%H:%M:%S"
     networks:
       - frontend
       - backend
@@ -108,6 +109,7 @@ services:
         awslogs-region: ${AWS_REGION}
         awslogs-group: ${AWS_LOG_GROUP}
         awslogs-stream: certbot
+        awslogs-multiline-pattern: "^Saving debug log to"
     volumes:
       - ./certbot/data:/var/www/certbot/:rw
       - ./certbot/conf:/etc/letsencrypt/:rw
@@ -125,6 +127,7 @@ services:
         awslogs-region: ${AWS_REGION}
         awslogs-group: ${AWS_LOG_GROUP}
         awslogs-stream: autoheal
+        awslogs-multiline-pattern: "^AUTOHEAL_CONTAINER_LABEL"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:


### PR DESCRIPTION
### 변경점

- #44 확인해보려고 CloudWatch Log를 확인하는데 아래와 같이 line 당 하나의 item으로 수집하고 있었습니다.
    ![스크린샷 2024-10-14 130550](https://github.com/user-attachments/assets/16af1acf-b0f1-4afb-9cea-339cbb4adbd5)
- 아무래도 log를 event 건당 묶는게 나을 듯 하여 아래와 같이 수정합니다.
    ![스크린샷 2024-10-14 141146](https://github.com/user-attachments/assets/b2160d89-ace7-4703-ac91-777317e6e692)
