### PR TITLE
Fix : discord message sending

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordClient.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordClient.java
@@ -1,6 +1,5 @@
 package gdsc.konkuk.platformcore.external.discord;
 
-import java.net.URI;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -21,14 +21,20 @@ public class DiscordClient {
 
   private final RestTemplate restTemplate;
 
+  /***
+   * Discord Webhook을 통해 에러메세지를 전송한다.
+   * @param e 발생한 Exception
+   * @author ekgns33
+   */
   public void sendErrorMessage(Exception e) {
     DiscordMessage message = DiscordMessage.of(e);
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     HttpEntity<DiscordMessage> entity = new HttpEntity<>(message, headers);
     try {
-      restTemplate.postForObject(URI.create(WEB_HOOK_URL), entity, String.class);
+      restTemplate.postForObject(UriComponentsBuilder.fromUriString(WEB_HOOK_URL).toUriString(), entity, String.class);
     } catch (Exception ex) {
+      //TODO: 웹훅 요청 자체가 잘못된 경우에 대한 처리 고안해야함.
       log.error(Arrays.toString(ex.getStackTrace()));
     }
   }

--- a/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordEmbed.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordEmbed.java
@@ -5,9 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DiscordEmbed {
+public class DiscordEmbed implements Serializable {
 
   private String title;
   private String description;

--- a/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordMessage.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordMessage.java
@@ -4,6 +4,7 @@ import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_E
 import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_ERROR_TIME_TEXT;
 import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_ERROR_TITLE;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,35 +15,58 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DiscordMessage {
+public class DiscordMessage implements Serializable {
 
+  private final static int MAX_STACK_DEPTH = 2;
   private String content;
   private List<DiscordEmbed> embeds = new ArrayList<>();
 
-  public DiscordMessage(String content){
+  public DiscordMessage(String content) {
     this.content = content;
   }
 
-  public void addEmbed(DiscordEmbed embed){
+  public void addEmbed(DiscordEmbed embed) {
     embeds.add(embed);
   }
 
+  /***
+   * Exception을 DiscordMessage로 변환하는 정적 메서드
+   * DiscordMessage는 Discord의 Webhook을 통해 메세지를 전송하기 위한 클래스이다.
+   * @param e 발생한 Exception
+   * @return {@link DiscordMessage} 클래스의 인스턴스를 반환한다.
+   * @author ekgns33
+   */
   public static DiscordMessage of(Exception e) {
     DiscordMessage ret = new DiscordMessage(DISCORD_ERROR_TITLE);
     DiscordEmbed embed = DiscordEmbed.builder()
-        .title(e.getMessage())
-        .description(
-            DISCORD_ERROR_DESCRIPTION
-                + "\n"
-                + DISCORD_ERROR_TIME_TEXT
-                + LocalDateTime.now()
-                + "\n"
-                + "```\n"
-                + Arrays.toString(e.getStackTrace())
-                + "\n```"
-        )
-        .build();
+            .title(e.getMessage())
+            .description(
+                    DISCORD_ERROR_DESCRIPTION
+                            + "\n"
+                            + DISCORD_ERROR_TIME_TEXT
+                            + LocalDateTime.now()
+                            + "\n"
+                            + "```\n"
+                            + getReducedStackTrace(e)
+                            + "\n```"
+            )
+            .build();
     ret.addEmbed(embed);
     return ret;
+  }
+
+  /***
+   * 스택트레이스의 최대 2개의 요소만을 반환한다. 디스코드의 Description에는 2048자가 최대길이이다.
+   * https://discord.com/safety/using-webhooks-and-embeds
+   *
+   * @param e 발생한 Exception
+   * @return 최대 2개의 스택트레이스 요소를 concat한 문자열 : String
+   * @author ekgns33
+   */
+  private static String getReducedStackTrace(Exception e) {
+    return Arrays.stream(e.getStackTrace())
+            .limit(MAX_STACK_DEPTH)
+            .map(StackTraceElement::toString)
+            .reduce("", (acc, cur) -> acc + "\n" + cur);
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordMessage.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordMessage.java
@@ -19,7 +19,7 @@ public class DiscordMessage implements Serializable {
 
   private final static int MAX_STACK_DEPTH = 2;
   private String content;
-  private List<DiscordEmbed> embeds = new ArrayList<>();
+  private final List<DiscordEmbed> embeds = new ArrayList<>();
 
   public DiscordMessage(String content) {
     this.content = content;
@@ -57,7 +57,7 @@ public class DiscordMessage implements Serializable {
 
   /***
    * 스택트레이스의 최대 2개의 요소만을 반환한다. 디스코드의 Description에는 2048자가 최대길이이다.
-   * https://discord.com/safety/using-webhooks-and-embeds
+   * <a href="https://discord.com/safety/using-webhooks-and-embeds">디스코드 임베딩 규칙</a>
    *
    * @param e 발생한 Exception
    * @return 최대 2개의 스택트레이스 요소를 concat한 문자열 : String

--- a/src/test/java/gdsc/konkuk/platformcore/external/discord/DiscordClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/discord/DiscordClientTest.java
@@ -6,7 +6,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailClientErrorCode;
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
-import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +42,6 @@ class DiscordClientTest {
     subject.sendErrorMessage(e);
 
     // then
-    verify(restTemplate).postForObject(any(URI.class), any(), any());
+    verify(restTemplate).postForObject(any(String.class), any(), any());
   }
 }


### PR DESCRIPTION
### 작업내용

- 디스코드 채널 변동에 따른 .env 웹훅 수정 및 서버에 반영
- 간헐적으로 디스코드 전송이 안되던 에러 추적
 
1. `URI` 클래스의 정적메서드 사용에서, `UriComponentBuilder`로 전환 
2. 디스코드 정책상 메세지의 각 임베딩마다 제한사항이 있음. [디스코드 웹훅 임베딩 룰](https://discord.com/safety/using-webhooks-and-embeds)
3. Exceptipn을 그대로 description에 넣은 문자열이 너무 길어서 400 응답을 받는것을 확인 (2048자 이상)

- 발생했던 에러 : [400, embeds-0](https://stackoverflow.com/questions/53935198/in-my-discord-webhook-i-am-getting-the-error-embeds-0)
4. 스택트레이스 요소를 최대 2개까지만 포함하도록 작성. << 임시

### 논의할 내용
<img width="518" alt="Screenshot 2024-10-26 at 5 19 42 PM" src="https://github.com/user-attachments/assets/ac09960d-c3c7-4c09-9a32-7a1d3ceedffc">

스택트레이스를 2개만 찍도록 한 것은 임시방편입니다! 짧긴 하지만 디스코드에서는 **어떤 부분에서 에러가 발생한 것**만 파악하고 실제 로그를 파악하려면 서버의 로그를 직접 보지않을까라는 생각에서 그냥 2개만 넣었어요.

- 디스코드로 특정 에러를 전송하는 로직은 개발자가 작성하기에 치명적인 에러가 발생하면 어느정도 파악할 수 있다고 생각함.

"그냥 에러 다찍고 2048자 넘는지 확인하자!" 이게 더 중요하다고 생각하시면 그 방향으로 가도 좋아요!