### PR TITLE
[Feat] member management

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
   private final AttendanceRepository attendanceRepository;
   private final ParticipantRepository participantRepository;
 
-  public List<Member> getMembers(String batch) {
+  public List<Member> getMembersInBatch(String batch) {
     return memberRepository.findAllActiveByBatch(batch);
   }
 

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
@@ -55,6 +55,7 @@ public class MemberService {
     member.withdraw();
   }
 
+  @Transactional
   public void updateMembers(String batch, @Valid List<MemberUpdateInfo> updateInfos) {
     Map<Long, Member> memberMap = fetchMembers(batch);
     updateMembers(memberMap, updateInfos);

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
@@ -38,6 +38,10 @@ public class MemberService {
   private final AttendanceRepository attendanceRepository;
   private final ParticipantRepository participantRepository;
 
+  public List<Member> getMembers(String batch) {
+    return memberRepository.findAllActiveByBatch(batch);
+  }
+
   @Transactional
   public Member register(MemberRegisterRequest registerRequest) {
     if (checkMemberExistWithStudentId(registerRequest.getStudentId())) {

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberUpdateCommand.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberUpdateCommand.java
@@ -1,0 +1,21 @@
+package gdsc.konkuk.platformcore.application.member.dtos;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class MemberUpdateCommand {
+  @NotNull private Long memberId;
+  private String studentId;
+  private String name;
+  private String email;
+  private String department;
+  private String batch;
+  private String role;
+}

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
@@ -3,6 +3,7 @@ package gdsc.konkuk.platformcore.controller.member;
 import gdsc.konkuk.platformcore.application.member.dtos.MemberAttendances;
 import gdsc.konkuk.platformcore.controller.member.dtos.AttendanceUpdateRequest;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberRegisterRequest;
+import gdsc.konkuk.platformcore.controller.member.dtos.MemberUpdateRequest;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
@@ -47,6 +48,13 @@ public class MemberController {
     memberService.withdraw(currentId);
     return ResponseEntity.noContent().build();
   }
+
+  @PatchMapping("/{batch}")
+    public ResponseEntity<SuccessResponse> updateMembers(
+        @PathVariable String batch, @RequestBody @Valid MemberUpdateRequest updateInfos) {
+        memberService.updateMembers(batch, updateInfos.getMemberUpdateInfoList());
+        return ResponseEntity.ok(SuccessResponse.messageOnly());
+    }
 
   @GetMapping("/{batch}/attendances")
   public ResponseEntity<SuccessResponse> getAttendances(

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
@@ -2,6 +2,7 @@ package gdsc.konkuk.platformcore.controller.member;
 
 import gdsc.konkuk.platformcore.application.member.dtos.MemberAttendances;
 import gdsc.konkuk.platformcore.controller.member.dtos.AttendanceUpdateRequest;
+import gdsc.konkuk.platformcore.controller.member.dtos.MemberInfo;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberRegisterRequest;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberUpdateRequest;
 import java.net.URI;
@@ -32,6 +33,14 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
   private final MemberService memberService;
+
+  @GetMapping("/{batch}")
+    public ResponseEntity<SuccessResponse> getMembers(@PathVariable String batch) {
+      List<MemberInfo> memberInfos = memberService.getMembers(batch).stream()
+          .map(MemberInfo::from)
+          .toList();
+      return ResponseEntity.ok(SuccessResponse.of(memberInfos));
+    }
 
   @PostMapping()
   public ResponseEntity<SuccessResponse> signup(

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
@@ -22,7 +22,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import gdsc.konkuk.platformcore.application.member.MemberService;
 import gdsc.konkuk.platformcore.domain.member.entity.Member;
-import gdsc.konkuk.platformcore.global.utils.SecurityUtils;
 import gdsc.konkuk.platformcore.global.responses.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,10 +41,11 @@ public class MemberController {
         .body(SuccessResponse.messageOnly());
   }
 
-  @DeleteMapping()
-  public ResponseEntity<SuccessResponse> withdraw() {
-    Long currentId = SecurityUtils.getCurrentUserId();
-    memberService.withdraw(currentId);
+  @DeleteMapping("/{batch}/{memberId}")
+  public ResponseEntity<SuccessResponse> withdraw(
+        @PathVariable String batch, @PathVariable Long memberId
+  ) {
+    memberService.withdraw(memberId);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
 
   @GetMapping("/{batch}")
     public ResponseEntity<SuccessResponse> getMembers(@PathVariable String batch) {
-      List<MemberInfo> memberInfos = memberService.getMembers(batch).stream()
+      List<MemberInfo> memberInfos = memberService.getMembersInBatch(batch).stream()
           .map(MemberInfo::from)
           .toList();
       return ResponseEntity.ok(SuccessResponse.of(memberInfos));

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberInfo.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberInfo.java
@@ -1,0 +1,31 @@
+package gdsc.konkuk.platformcore.controller.member.dtos;
+
+import gdsc.konkuk.platformcore.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MemberInfo {
+  private Long memberId;
+  private String studentId;
+  private String name;
+  private String email;
+  private String department;
+  private String batch;
+  private String role;
+
+  public static MemberInfo from(Member member) {
+    return MemberInfo.builder()
+        .memberId(member.getId())
+        .studentId(member.getStudentId())
+        .name(member.getName())
+        .email(member.getEmail())
+        .department(member.getDepartment())
+        .batch(member.getBatch())
+        .role(member.getRole().toString())
+        .build();
+  }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberUpdateInfo.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberUpdateInfo.java
@@ -1,6 +1,6 @@
 package gdsc.konkuk.platformcore.controller.member.dtos;
 
-import gdsc.konkuk.platformcore.domain.member.entity.Member;
+import gdsc.konkuk.platformcore.application.member.dtos.MemberUpdateCommand;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,24 +18,15 @@ public class MemberUpdateInfo {
   private String batch;
   private String role;
 
-  public void updateEntity(Member member) {
-    if (studentId != null) {
-      member.updateStudentId(studentId);
-    }
-    if (name != null) {
-      member.updateName(name);
-    }
-    if (email != null) {
-      member.updateEmail(email);
-    }
-    if (department != null) {
-      member.updateDepartment(department);
-    }
-    if (batch != null) {
-      member.updateBatch(batch);
-    }
-    if (role != null) {
-      member.updateRole(role);
-    }
+  public MemberUpdateCommand toCommand() {
+    return MemberUpdateCommand.builder()
+        .memberId(memberId)
+        .studentId(studentId)
+        .name(name)
+        .email(email)
+        .department(department)
+        .batch(batch)
+        .role(role)
+        .build();
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberUpdateInfo.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberUpdateInfo.java
@@ -1,0 +1,41 @@
+package gdsc.konkuk.platformcore.controller.member.dtos;
+
+import gdsc.konkuk.platformcore.domain.member.entity.Member;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MemberUpdateInfo {
+  @NotNull private Long memberId;
+  private String studentId;
+  private String name;
+  private String email;
+  private String department;
+  private String batch;
+  private String role;
+
+  public void updateEntity(Member member) {
+    if (studentId != null) {
+      member.updateStudentId(studentId);
+    }
+    if (name != null) {
+      member.updateName(name);
+    }
+    if (email != null) {
+      member.updateEmail(email);
+    }
+    if (department != null) {
+      member.updateDepartment(department);
+    }
+    if (batch != null) {
+      member.updateBatch(batch);
+    }
+    if (role != null) {
+      member.updateRole(role);
+    }
+  }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberUpdateRequest.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/MemberUpdateRequest.java
@@ -1,0 +1,21 @@
+package gdsc.konkuk.platformcore.controller.member.dtos;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUpdateRequest {
+    @NotNull
+    @Valid
+    private List<MemberUpdateInfo> memberUpdateInfoList;
+}

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package gdsc.konkuk.platformcore.domain.member.entity;
 import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.SOFT_DELETE_RETENTION_MONTHS;
 import static gdsc.konkuk.platformcore.global.utils.FieldValidator.validateNotNull;
 
+import gdsc.konkuk.platformcore.application.member.dtos.MemberUpdateCommand;
 import java.time.LocalDateTime;
 
 import org.hibernate.annotations.SQLRestriction;
@@ -68,28 +69,25 @@ public class Member {
     return isDeleted;
   }
 
-  public void updateStudentId(String studentId) {
-    this.studentId = studentId;
-  }
-
-  public void updateName(String name) {
-      this.name = name;
-  }
-
-  public void updateEmail(String email) {
-      this.email = email;
-  }
-
-  public void updateDepartment(String department) {
-      this.department = department;
-  }
-
-  public void updateRole(String role) {
-      this.role = MemberRole.from(role);
-  }
-
-  public void updateBatch(String batch) {
-      this.batch = batch;
+  public void update(MemberUpdateCommand command) {
+    if (command.getStudentId() != null) {
+      studentId = command.getStudentId();
+    }
+    if (command.getName() != null) {
+      name = command.getName();
+    }
+    if (command.getEmail() != null) {
+      email = command.getEmail();
+    }
+    if (command.getDepartment() != null) {
+      department = command.getDepartment();
+    }
+    if (command.getRole() != null) {
+      role = MemberRole.from(command.getRole());
+    }
+    if (command.getBatch() != null) {
+      batch = command.getBatch();
+    }
   }
 
   @Builder

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
@@ -68,6 +68,30 @@ public class Member {
     return isDeleted;
   }
 
+  public void updateStudentId(String studentId) {
+    this.studentId = studentId;
+  }
+
+  public void updateName(String name) {
+      this.name = name;
+  }
+
+  public void updateEmail(String email) {
+      this.email = email;
+  }
+
+  public void updateDepartment(String department) {
+      this.department = department;
+  }
+
+  public void updateRole(String role) {
+      this.role = MemberRole.from(role);
+  }
+
+  public void updateBatch(String batch) {
+      this.batch = batch;
+  }
+
   @Builder
   public Member(
       Long id,

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
@@ -6,8 +6,12 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import gdsc.konkuk.platformcore.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+  @Query("SELECT m FROM Member m WHERE m.batch = :batch AND m.isDeleted = false")
+  List<Member> findAllActiveByBatch(String batch);
+
   Optional<Member> findByStudentId(String studentId);
 
   Optional<Member> findByEmail(String memberEmail);

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
@@ -12,6 +12,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   @Query("SELECT m FROM Member m WHERE m.batch = :batch AND m.isDeleted = false")
   List<Member> findAllActiveByBatch(String batch);
 
+  @Query("SELECT m FROM Member m WHERE m.id IN :memberIds AND m.batch = :batch")
+  List<Member> findAllByIdsAndBatch(List<Long> memberIds, String batch);
+
   Optional<Member> findByStudentId(String studentId);
 
   Optional<Member> findByEmail(String memberEmail);

--- a/src/main/java/gdsc/konkuk/platformcore/global/configs/SecurityConfig.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/configs/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(authorize -> authorize
             // 모두를 위한 API
-            .requestMatchers("/login/**", "/docs/**", "/actuator/**", apiPath("/members"))
+            .requestMatchers("/login/**", "/docs/**", "/actuator/**")
             .permitAll()
             // 동아리 회원을 위한 API
             .requestMatchers(apiPath("/attendances/attend/**"))

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -116,6 +116,8 @@ class MemberControllerTest {
   @DisplayName("새로운 멤버 회원 가입 성공")
   void should_success_when_newMember() throws Exception {
     // given
+    Member member = MemberFixture.builder().role(MemberRole.CORE).build().getFixture();
+    String jwt = jwtTokenProvider.createToken(member);
     MemberRegisterRequest memberRegisterRequest = MemberRegisterRequestFixture.builder()
         .studentId("202400000").build().getFixture();
     Member memberToRegister = MemberFixture.builder()
@@ -127,6 +129,7 @@ class MemberControllerTest {
         mockMvc.perform(
             RestDocumentationRequestBuilders.post("/api/v1/members")
                 .contentType(APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwt)
                 .content(objectMapper.writeValueAsString(memberRegisterRequest))
                 .with(csrf()));
 
@@ -162,6 +165,8 @@ class MemberControllerTest {
   @DisplayName("이미 존재하는 유저 회원 가입 실패")
   void should_fail_when_existingMember() throws Exception {
     // given
+    Member member = MemberFixture.builder().role(MemberRole.CORE).build().getFixture();
+    String jwt = jwtTokenProvider.createToken(member);
     MemberRegisterRequest memberRegisterRequest = MemberRegisterRequestFixture.builder().build().getFixture();
     given(memberService.register(any(MemberRegisterRequest.class)))
         .willThrow(UserAlreadyExistException.class);
@@ -171,6 +176,7 @@ class MemberControllerTest {
         mockMvc.perform(
             RestDocumentationRequestBuilders.post("/api/v1/members")
                 .contentType(APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwt)
                 .content(objectMapper.writeValueAsString(memberRegisterRequest))
                 .with(csrf()));
 

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -65,6 +65,54 @@ class MemberControllerTest {
   }
 
   @Test
+  @DisplayName("특정 기수의 멤버 목록 조회 성공")
+  void should_success_when_get_members() throws Exception {
+    // given
+    Member member = MemberFixture.builder().role(MemberRole.CORE).build().getFixture();
+    String jwt = jwtTokenProvider.createToken(member);
+    given(memberService.getMembers("24-25"))
+        .willReturn(
+            List.of(
+                MemberFixture.builder().id(0L).batch("24-25").build().getFixture(),
+                MemberFixture.builder().id(1L).batch("24-25").build().getFixture(),
+                MemberFixture.builder().id(2L).batch("24-25").build().getFixture()));
+
+    // when
+    ResultActions result =
+        mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/v1/members/{batch}", "24-25")
+                .header("Authorization", "Bearer " + jwt)
+                .contentType(APPLICATION_JSON)
+                .with(csrf()));
+
+    // then
+    result
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "member/get_members",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("특정 기수의 멤버 목록 조회")
+                        .tag("member")
+                        .pathParameters(parameterWithName("batch").description("조회할 멤버 기수"))
+                        .responseFields(
+                            fieldWithPath("success").description(true),
+                            fieldWithPath("message").description("멤버 목록 조회 성공"),
+                            fieldWithPath("data[].memberId").description("멤버 아이디"),
+                            fieldWithPath("data[].studentId").description("학번"),
+                            fieldWithPath("data[].email").description("이메일"),
+                            fieldWithPath("data[].name").description("이름"),
+                            fieldWithPath("data[].department").description("학과"),
+                            fieldWithPath("data[].batch").description("배치"),
+                            fieldWithPath("data[].role").description("역할"))
+                        .build())));
+  }
+
+  @Test
   @DisplayName("새로운 멤버 회원 가입 성공")
   void should_success_when_newMember() throws Exception {
     // given

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -134,7 +134,7 @@ class MemberControllerTest {
   @DisplayName("회원 탈퇴 성공")
   void should_success_when_delete_member() throws Exception {
     // given
-    Member member = MemberFixture.builder().role(MemberRole.MEMBER).build().getFixture();
+    Member member = MemberFixture.builder().role(MemberRole.CORE).build().getFixture();
     String jwt = jwtTokenProvider.createToken(member);
     Member memberToWithdraw = MemberFixture.builder().build().getFixture();
     willDoNothing().given(memberService).withdraw(memberToWithdraw.getId());
@@ -142,7 +142,8 @@ class MemberControllerTest {
     // when
     ResultActions result =
         mockMvc.perform(
-            RestDocumentationRequestBuilders.delete("/api/v1/members")
+            RestDocumentationRequestBuilders
+                .delete("/api/v1/members/{batch}/{memberId}", "24-25", 1L)
                 .header("Authorization", "Bearer " + jwt)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()));
@@ -160,6 +161,9 @@ class MemberControllerTest {
                     ResourceSnippetParameters.builder()
                         .description("존재하는 회원 탈퇴")
                         .tag("member")
+                        .pathParameters(
+                          parameterWithName("batch").description("탈퇴할 멤버 기수"),
+                          parameterWithName("memberId").description("탈퇴할 멤버 아이디"))
                         .build())));
   }
 

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -70,7 +70,7 @@ class MemberControllerTest {
     // given
     Member member = MemberFixture.builder().role(MemberRole.CORE).build().getFixture();
     String jwt = jwtTokenProvider.createToken(member);
-    given(memberService.getMembers("24-25"))
+    given(memberService.getMembersInBatch("24-25"))
         .willReturn(
             List.of(
                 MemberFixture.builder().id(0L).batch("24-25").build().getFixture(),


### PR DESCRIPTION
### 한 일

- 회원 정보 수정 API 구현
- 회원 탈퇴를 현 로그인 유저를 삭제하는것이 아닌, 운영진이 특정 유저를 삭제하는 방식으로 변경
- 회원 목록 조회

### ? 발생 예상 지점

```java
  @DeleteMapping("/{batch}/{memberId}")
  public ResponseEntity<SuccessResponse> withdraw(
        @PathVariable String batch, @PathVariable Long memberId
  ) {
    memberService.withdraw(memberId);
    return ResponseEntity.noContent().build();
  }
```

**Q**. `batch` 왜 받아요?
**A**. API 설계시에 이미 `/members/batch`의 구조를 가져가고 있어서 일관성을 위해

그런데 근거가 많이 빈약하죠? 막상 `batch` 받아다가 쓰는 건 아니다 보니. 그래서 그냥 `memberId`만 받게 할라 하다가 문득 의견이 궁금해서 올려봤습니다.
