### PR TITLE
[Feat] late attendance

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/attendance/AttendanceService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/attendance/AttendanceService.java
@@ -6,6 +6,7 @@ import gdsc.konkuk.platformcore.application.attendance.dtos.AttendanceStatus;
 import gdsc.konkuk.platformcore.application.member.exceptions.MemberErrorCode;
 import gdsc.konkuk.platformcore.application.member.exceptions.UserNotFoundException;
 import gdsc.konkuk.platformcore.domain.attendance.entity.Attendance;
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.attendance.entity.Participant;
 import gdsc.konkuk.platformcore.domain.attendance.repository.AttendanceRepository;
 import gdsc.konkuk.platformcore.domain.attendance.repository.ParticipantRepository;
@@ -56,7 +57,7 @@ public class AttendanceService {
 
   public AttendanceStatus getAttendanceStatus(Long attendanceId) {
     List<Participant> totalParticipants = participantRepository.findAllByAttendanceId(attendanceId);
-    List<Participant> attendedParticipants = totalParticipants.stream().filter(Participant::isAttended).toList();
+    List<Participant> attendedParticipants = totalParticipants.stream().filter(Participant::isAttend).toList();
     return AttendanceStatus.of(attendanceId, totalParticipants.size(), attendedParticipants.size());
   }
 
@@ -84,7 +85,7 @@ public class AttendanceService {
     for(Member member : members) {
       Participant participant = Participant.builder()
           .memberId(member.getId())
-          .isAttended(false)
+          .attendanceType(AttendanceType.ABSENT)
           .build();
       participant.register(attendance);
       participants.add(participant);

--- a/src/main/java/gdsc/konkuk/platformcore/application/attendance/dtos/MemberAttendanceInfo.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/attendance/dtos/MemberAttendanceInfo.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.application.attendance.dtos;
 
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,9 +12,8 @@ import lombok.Getter;
 @Builder
 public class MemberAttendanceInfo {
   private Long attendanceId;
-  private Long eventId;
   private Long memberId;
-  private boolean isAttended;
+  private AttendanceType attendanceType;
   private LocalDateTime attendanceDate;
   private Long participantId;
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/attendance/dtos/MemberAttendanceQueryDto.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/attendance/dtos/MemberAttendanceQueryDto.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.application.attendance.dtos;
 
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -19,5 +20,5 @@ public class MemberAttendanceQueryDto {
   private Long participantId;
   private Long attendanceId;
   private LocalDateTime attendanceDate;
-  private boolean isAttended;
+  private AttendanceType attendanceType;
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
@@ -106,7 +106,7 @@ public class MemberService {
         throw ParticipantNotFoundException.of(AttendanceErrorCode.PARTICIPANT_NOT_FOUND);
       }
       Participant participant = participants.get(attendanceUpdateInfo.getParticipantId());
-      participant.updateAttendanceStatus(attendanceUpdateInfo.isAttended());
+      participant.updateAttendanceStatus(attendanceUpdateInfo.getAttendanceType());
     }
   }
 

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberAttendances.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberAttendances.java
@@ -2,6 +2,7 @@ package gdsc.konkuk.platformcore.application.member.dtos;
 
 import gdsc.konkuk.platformcore.application.attendance.dtos.MemberAttendanceInfo;
 import gdsc.konkuk.platformcore.application.attendance.dtos.MemberAttendanceQueryDto;
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -41,7 +42,7 @@ public class MemberAttendances{
 
   private static void updateAttendanceCounts(MemberAttendances memberAttendances, MemberAttendanceQueryDto attendanceInfo) {
     memberAttendances.totalAttendances++;
-    if (attendanceInfo.isAttended()) {
+    if (!attendanceInfo.getAttendanceType().equals(AttendanceType.ABSENT)) {
       memberAttendances.actualAttendances++;
     }
   }
@@ -64,7 +65,7 @@ public class MemberAttendances{
         .attendanceDate(attendanceInfo.getAttendanceDate())
         .participantId(attendanceInfo.getParticipantId())
         .attendanceId(attendanceInfo.getAttendanceId())
-        .isAttended(attendanceInfo.isAttended())
+        .attendanceType(attendanceInfo.getAttendanceType())
         .build();
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberAttendances.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberAttendances.java
@@ -41,6 +41,7 @@ public class MemberAttendances{
   }
 
   private static void updateAttendanceCounts(MemberAttendances memberAttendances, MemberAttendanceQueryDto attendanceInfo) {
+    // TODO : 너무 높아진 복잡도, 리팩터링 필요
     memberAttendances.totalAttendances++;
     if (!attendanceInfo.getAttendanceType().equals(AttendanceType.ABSENT)) {
       memberAttendances.actualAttendances++;

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberAttendances.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/dtos/MemberAttendances.java
@@ -2,7 +2,6 @@ package gdsc.konkuk.platformcore.application.member.dtos;
 
 import gdsc.konkuk.platformcore.application.attendance.dtos.MemberAttendanceInfo;
 import gdsc.konkuk.platformcore.application.attendance.dtos.MemberAttendanceQueryDto;
-import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -43,7 +42,7 @@ public class MemberAttendances{
   private static void updateAttendanceCounts(MemberAttendances memberAttendances, MemberAttendanceQueryDto attendanceInfo) {
     // TODO : 너무 높아진 복잡도, 리팩터링 필요
     memberAttendances.totalAttendances++;
-    if (!attendanceInfo.getAttendanceType().equals(AttendanceType.ABSENT)) {
+    if (!attendanceInfo.getAttendanceType().isAbsent()) {
       memberAttendances.actualAttendances++;
     }
   }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/AttendanceUpdateInfo.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/dtos/AttendanceUpdateInfo.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.controller.member.dtos;
 
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +11,5 @@ import lombok.Setter;
 @Builder
 public class AttendanceUpdateInfo {
   @NotNull private Long participantId;
-  @NotNull private boolean isAttended;
+  @NotNull private AttendanceType attendanceType;
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/AttendanceType.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/AttendanceType.java
@@ -1,0 +1,16 @@
+package gdsc.konkuk.platformcore.domain.attendance.entity;
+
+public enum AttendanceType {
+    ATTEND("ATTEND"), ABSENT("ABSENT"), LATE("LATE"),;
+
+    private final String value;
+
+    AttendanceType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/AttendanceType.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/AttendanceType.java
@@ -9,6 +9,10 @@ public enum AttendanceType {
         this.value = value;
     }
 
+    public boolean isAbsent() {
+        return this == ABSENT;
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/Participant.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/Participant.java
@@ -49,7 +49,7 @@ public class Participant {
   }
 
   public boolean isAttend() {
-    return !this.attendanceType.equals(AttendanceType.ABSENT);
+    return !this.attendanceType.isAbsent();
   }
 
   public void attend() {

--- a/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/Participant.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/attendance/entity/Participant.java
@@ -2,6 +2,8 @@ package gdsc.konkuk.platformcore.domain.attendance.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,32 +30,33 @@ public class Participant {
   @Column(name = "member_id")
   private Long memberId;
 
-  @Column(name = "attendance")
-  private boolean isAttended;
+  @Column(name = "attendance_type")
+  @Enumerated(EnumType.STRING)
+  private AttendanceType attendanceType;
 
   @Builder
-  public Participant(Long memberId, Attendance attendance, boolean isAttended) {
+  public Participant(Long memberId, Attendance attendance, AttendanceType attendanceType) {
     this.memberId = memberId;
     this.attendance = attendance;
-    this.isAttended = isAttended;
+    this.attendanceType = attendanceType;
   }
 
   public void register(Attendance attendance) {
-    if(isAttended || attendance == null) {
+    if(this.attendance != null || attendance == null) {
       throw new IllegalStateException();
     }
     this.attendance = attendance;
   }
 
+  public boolean isAttend() {
+    return !this.attendanceType.equals(AttendanceType.ABSENT);
+  }
+
   public void attend() {
-    this.isAttended = true;
+    this.attendanceType = AttendanceType.ATTEND;
   }
 
-  public void cancel() {
-    this.isAttended = false;
-  }
-
-  public void updateAttendanceStatus(boolean isAttended) {
-    this.isAttended = isAttended;
+  public void updateAttendanceStatus(AttendanceType isAttended) {
+    this.attendanceType = isAttended;
   }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/attendance/repository/AttendanceRepository.java
@@ -14,7 +14,7 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
   List<Attendance> findAllByPeriod(LocalDateTime st, LocalDateTime en);
 
   @Query("SELECT new gdsc.konkuk.platformcore.application.attendance.dtos.MemberAttendanceQueryDto(" +
-      "m.id, m.name, m.role, m.department, p.id, a.id, a.attendanceTime, p.isAttended) " +
+      "m.id, m.name, m.role, m.department, p.id, a.id, a.attendanceTime, p.attendanceType) " +
       "FROM Attendance a " +
       "LEFT JOIN Participant p ON p.attendance.id = a.id " +
       "LEFT JOIN Member m ON m.id = p.memberId " +

--- a/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
@@ -10,6 +10,7 @@ import gdsc.konkuk.platformcore.application.auth.JwtTokenProvider;
 import gdsc.konkuk.platformcore.controller.attendance.dtos.AttendanceRegisterRequest;
 import gdsc.konkuk.platformcore.domain.attendance.entity.Attendance;
 
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.member.entity.Member;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import gdsc.konkuk.platformcore.fixture.attendance.AttendanceFixture;
@@ -139,7 +140,7 @@ class AttendanceControllerTest {
         .id(1L).activeQrUuid("uuid").build().getFixture();
     given(attendanceService.attend(memberToAttend.getId(), attendanceToAttend.getId(), attendanceToAttend.getActiveQrUuid()))
         .willReturn(ParticipantFixture.builder()
-            .isAttended(true)
+            .attendanceType(AttendanceType.ATTEND)
             .memberId(memberToAttend.getId())
             .attendance(attendanceToAttend)
             .build().getFixture());

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -22,6 +22,7 @@ import gdsc.konkuk.platformcore.controller.member.dtos.AttendanceUpdateRequest;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberRegisterRequest;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberUpdateInfo;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberUpdateRequest;
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.member.entity.Member;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import gdsc.konkuk.platformcore.fixture.member.MemberAttendancesFixture;
@@ -324,18 +325,15 @@ class MemberControllerTest {
                             fieldWithPath("data[].department").description("멤버 학과"),
                             fieldWithPath("data[].totalAttendances").description("전체 등록 횟수"),
                             fieldWithPath("data[].actualAttendances").description("실제 출석 횟수"),
-                            fieldWithPath("data[].attendanceInfoList").description("멤버 출석 정보 리스트"),
                             fieldWithPath("data[].attendanceInfoList[].attendanceId")
                                 .description("출석 아이디"),
                             fieldWithPath("data[].attendanceInfoList[].memberId")
                                 .description("멤버 아이디"),
-                            fieldWithPath("data[].attendanceInfoList[].eventId")
-                                .description("이벤트 아이디"),
                             fieldWithPath("data[].attendanceInfoList[].participantId")
                                 .description("참가자 아이디"),
                             fieldWithPath("data[].attendanceInfoList[].attendanceDate")
                                 .description("출석 날짜"),
-                            fieldWithPath("data[].attendanceInfoList[].attended")
+                            fieldWithPath("data[].attendanceInfoList[].attendanceType")
                                 .description("출석 여부"))
                         .build())));
   }
@@ -347,9 +345,9 @@ class MemberControllerTest {
     Member member = MemberFixture.builder().role(MemberRole.CORE).build().getFixture();
     String jwt = jwtTokenProvider.createToken(member);
     List<AttendanceUpdateInfo> attendanceUpdateInfoList = List.of(
-            AttendanceUpdateInfo.builder().participantId(1L).isAttended(true).build(),
-            AttendanceUpdateInfo.builder().participantId(2L).isAttended(false).build(),
-            AttendanceUpdateInfo.builder().participantId(3L).isAttended(true).build());
+            AttendanceUpdateInfo.builder().participantId(1L).attendanceType(AttendanceType.ATTEND).build(),
+            AttendanceUpdateInfo.builder().participantId(2L).attendanceType(AttendanceType.ABSENT).build(),
+            AttendanceUpdateInfo.builder().participantId(3L).attendanceType(AttendanceType.LATE).build());
     AttendanceUpdateRequest attendanceUpdateRequest = new AttendanceUpdateRequest(attendanceUpdateInfoList);
     willDoNothing().given(memberService).updateAttendances(
             "24-25",
@@ -389,7 +387,7 @@ class MemberControllerTest {
                             fieldWithPath("attendanceUpdateInfoList[]").description("출석 정보 수정 리스트"),
                             fieldWithPath("attendanceUpdateInfoList[].participantId")
                                 .description("참가자 아이디"),
-                            fieldWithPath("attendanceUpdateInfoList[].attended")
+                            fieldWithPath("attendanceUpdateInfoList[].attendanceType")
                                 .description("출석 여부"))
                         .responseFields(
                             fieldWithPath("success").description(true),

--- a/src/test/java/gdsc/konkuk/platformcore/fixture/attendance/ParticipantFixture.java
+++ b/src/test/java/gdsc/konkuk/platformcore/fixture/attendance/ParticipantFixture.java
@@ -3,6 +3,7 @@ package gdsc.konkuk.platformcore.fixture.attendance;
 import static gdsc.konkuk.platformcore.global.utils.GetDefault.getDefault;
 
 import gdsc.konkuk.platformcore.domain.attendance.entity.Attendance;
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.attendance.entity.Participant;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,11 +13,11 @@ public class ParticipantFixture {
   private final Participant fixture;
 
   @Builder
-  public ParticipantFixture(Long memberId, Attendance attendance, Boolean isAttended) {
+  public ParticipantFixture(Long memberId, Attendance attendance, AttendanceType attendanceType) {
     this.fixture = Participant.builder()
       .memberId(getDefault(memberId, 0L))
       .attendance(getDefault(attendance, AttendanceFixture.builder().build().getFixture()))
-      .isAttended(getDefault(isAttended, false))
+      .attendanceType(getDefault(attendanceType, AttendanceType.ABSENT))
       .build();
   }
 }

--- a/src/test/java/gdsc/konkuk/platformcore/fixture/member/MemberAttendancesFixture.java
+++ b/src/test/java/gdsc/konkuk/platformcore/fixture/member/MemberAttendancesFixture.java
@@ -4,6 +4,7 @@ import static gdsc.konkuk.platformcore.global.utils.GetDefault.getDefault;
 
 import gdsc.konkuk.platformcore.application.attendance.dtos.MemberAttendanceInfo;
 import gdsc.konkuk.platformcore.application.member.dtos.MemberAttendances;
+import gdsc.konkuk.platformcore.domain.attendance.entity.AttendanceType;
 import gdsc.konkuk.platformcore.domain.member.entity.MemberRole;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,26 +28,23 @@ public class MemberAttendancesFixture {
         MemberAttendanceInfo.builder()
             .attendanceId(0L)
             .memberId(0L)
-            .eventId(0L)
             .participantId(0L)
+            .attendanceType(AttendanceType.ABSENT)
             .attendanceDate(LocalDateTime.now())
-            .isAttended(true)
             .build(),
         MemberAttendanceInfo.builder()
             .attendanceId(1L)
             .memberId(0L)
-            .eventId(1L)
             .participantId(1L)
+            .attendanceType(AttendanceType.LATE)
             .attendanceDate(LocalDateTime.now().plusDays(3))
-            .isAttended(false)
             .build(),
         MemberAttendanceInfo.builder()
             .attendanceId(2L)
             .memberId(0L)
-            .eventId(2L)
             .participantId(2L)
+            .attendanceType(AttendanceType.ATTEND)
             .attendanceDate(LocalDateTime.now().plusDays(5))
-            .isAttended(true)
             .build())))
       .build();
   }


### PR DESCRIPTION
### 하고자 한 일

- 출석에 지각 추가
- QR을 통한 출석은 "출석"과 "결석"만 가능하고, "지각"은 추후 운영진이 수동으로 선택하는 옵션
- 출석 현황과 출석비율 등을 반영할 때에, "지각"은 "출석"과 마찬가지로 취급
- `Event` 삭제가 반영되지 않은 DTO에 `eventId`와 같은 속성 제거
