### PR TITLE
[Fix] Set Login Redirection

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
@@ -1,5 +1,7 @@
 package gdsc.konkuk.platformcore.application.auth;
 
+import static gdsc.konkuk.platformcore.global.consts.SPAConstants.SPA_ADMIN_LOGIN_REDIRECT_URL;
+
 import gdsc.konkuk.platformcore.application.member.exceptions.MemberErrorCode;
 import gdsc.konkuk.platformcore.application.member.exceptions.UserNotFoundException;
 import gdsc.konkuk.platformcore.domain.member.entity.Member;
@@ -35,6 +37,6 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         response.addHeader("Authorization", "Bearer " + token);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.sendRedirect("https://admin.gdsc-konkuk.dev/oauth/callback");
+        response.sendRedirect(SPA_ADMIN_LOGIN_REDIRECT_URL);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
@@ -6,6 +6,7 @@ import gdsc.konkuk.platformcore.domain.member.entity.Member;
 import gdsc.konkuk.platformcore.domain.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -24,7 +25,7 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     @Override
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response,
-            Authentication authentication) {
+            Authentication authentication) throws IOException {
 
         OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
         Member member = memberRepository.findByEmail(oidcUser.getEmail())
@@ -34,5 +35,6 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         response.addHeader("Authorization", "Bearer " + token);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.sendRedirect("https://admin.gdsc-konkuk.dev/oauth/callback");
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
@@ -1,6 +1,8 @@
 package gdsc.konkuk.platformcore.controller.attendance;
 
 import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.apiPath;
+import static gdsc.konkuk.platformcore.global.consts.SPAConstants.SPA_ADMIN_ATTENDANCE_FAIL_REDIRECT_URL;
+import static gdsc.konkuk.platformcore.global.consts.SPAConstants.SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL;
 import static org.springframework.http.HttpStatusCode.valueOf;
 
 import gdsc.konkuk.platformcore.application.attendance.AttendanceService;
@@ -53,12 +55,12 @@ public class AttendanceController {
             Long currentId = SecurityUtils.getCurrentUserId();
             attendanceService.attend(currentId, attendanceId, qrUuid);
             HttpHeaders headers = new HttpHeaders();
-            headers.add("Location", "https://admin.gdsc-konkuk.dev/attendance-return/success");
+            headers.add("Location", SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL);
             return new ResponseEntity<>(headers,
                     valueOf(HttpServletResponse.SC_TEMPORARY_REDIRECT));
         } catch (Exception e) {
             HttpHeaders headers = new HttpHeaders();
-            headers.add("Location", "https://admin.gdsc-konkuk.dev/attendance-return/fail");
+            headers.add("Location", SPA_ADMIN_ATTENDANCE_FAIL_REDIRECT_URL);
             return new ResponseEntity<>(headers,
                     valueOf(HttpServletResponse.SC_TEMPORARY_REDIRECT));
         }

--- a/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordMessage.java
+++ b/src/main/java/gdsc/konkuk/platformcore/external/discord/DiscordMessage.java
@@ -1,8 +1,8 @@
 package gdsc.konkuk.platformcore.external.discord;
 
-import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_ERROR_DESCRIPTION;
-import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_ERROR_TIME_TEXT;
-import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_ERROR_TITLE;
+import static gdsc.konkuk.platformcore.global.consts.DiscordConstants.DISCORD_ERROR_DESCRIPTION;
+import static gdsc.konkuk.platformcore.global.consts.DiscordConstants.DISCORD_ERROR_TIME_TEXT;
+import static gdsc.konkuk.platformcore.global.consts.DiscordConstants.DISCORD_ERROR_TITLE;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/DiscordConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/DiscordConstants.java
@@ -1,0 +1,9 @@
+package gdsc.konkuk.platformcore.global.consts;
+
+public class DiscordConstants {
+
+    public static final String DISCORD_ERROR_TITLE = "\uD83E\uDDE8 치명적인 서버 에러 발생!";
+    public static final String DISCORD_ERROR_DESCRIPTION =
+            "\uD83C\uDD98 서버에서 치명적인 에러가 발생했습니다. 빠르게 확인해주세요. \uD83C\uDD98";
+    public static final String DISCORD_ERROR_TIME_TEXT = "\uD83D\uDD50 에러 발생 시간 : ";
+}

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
@@ -13,16 +13,9 @@ public class PlatformConstants {
             "https://member.gdsc-konkuk.dev", "https://landing.gdsc-konkuk.dev");
 
     public static final Integer SOFT_DELETE_RETENTION_MONTHS = 3;
-
-    public static final String LOGIN_NAME = "id";
-    public static final String API_PREFIX = "/api/v1";
-
     public static final String EMAIL_RECEIVER_NAME_REGEXP = "\\{이름}";
 
-    public static final String DISCORD_ERROR_TITLE = "\uD83E\uDDE8 치명적인 서버 에러 발생!";
-    public static final String DISCORD_ERROR_DESCRIPTION =
-            "\uD83C\uDD98 서버에서 치명적인 에러가 발생했습니다. 빠르게 확인해주세요. \uD83C\uDD98";
-    public static final String DISCORD_ERROR_TIME_TEXT = "\uD83D\uDD50 에러 발생 시간 : ";
+    public static final String API_PREFIX = "/api/v1";
 
     public static String apiPath(String path) {
         return API_PREFIX + path;

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/SPAConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/SPAConstants.java
@@ -1,0 +1,12 @@
+package gdsc.konkuk.platformcore.global.consts;
+
+public class SPAConstants {
+
+    public static final String SPA_ADMIN_BASE_URL = "https://admin.gdsc-konkuk.dev";
+    public static final String SPA_ADMIN_LOGIN_REDIRECT_URL =
+            SPA_ADMIN_BASE_URL + "/oauth/callback";
+    public static final String SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL =
+            SPA_ADMIN_BASE_URL + "/attendance-return/success";
+    public static final String SPA_ADMIN_ATTENDANCE_FAIL_REDIRECT_URL =
+            SPA_ADMIN_BASE_URL + "/attendance-return/fail";
+}

--- a/src/test/java/gdsc/konkuk/platformcore/external/discord/DiscordMessageTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/discord/DiscordMessageTest.java
@@ -1,6 +1,6 @@
 package gdsc.konkuk.platformcore.external.discord;
 
-import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.DISCORD_ERROR_TITLE;
+import static gdsc.konkuk.platformcore.global.consts.DiscordConstants.DISCORD_ERROR_TITLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import gdsc.konkuk.platformcore.application.email.exceptions.EmailErrorCode;


### PR DESCRIPTION
### 배경

OAuth로 사용자 인증을 이주했는데, 막상 로그인 성공 후 redirection을 설정하지 않은 상황입니다. 그래서 로그인을 성공한 후 SPA로 사용자가 재진입하도록 redirection을 설정합니다.

### 부가

resolve #59 

아무래도 Server Static Page를 만들지 않기로 합의한 상황에서는 상수화를 통한 컨트롤이 가장 단순하다고 생각하여 적용합니다. 이 과정에서 `Constants` 패키지를 조금 더 잘게 세분화했습니다.