### PR TITLE
[fix] move jwt to fragment

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
@@ -34,9 +34,8 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .orElseThrow(() -> UserNotFoundException.of(MemberErrorCode.USER_NOT_FOUND));
         String token = jwtTokenProvider.createToken(member);
 
-        response.addHeader("Authorization", "Bearer " + token);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.sendRedirect(SPA_ADMIN_LOGIN_REDIRECT_URL);
+        response.sendRedirect(SPA_ADMIN_LOGIN_REDIRECT_URL + "#" + token);
     }
 }


### PR DESCRIPTION
## 배경

이전 #64 에서 로그인 후 redirection을 설정했습니다. JWT를 authorization header에 전달했는데, 브라우져 보안 정책상 전달이 불가능한 문제가 있습니다.

### Reference

[1] https://stackoverflow.com/questions/28564961/authorization-header-is-lost-on-redirect

## 적용 방법

JWT를 URL fragment로 이동합니다.

우선, 위 문제를 해결 가능한 가장 손쉬운 방법은 JWT를 URL 안에 포함하는 것입니다. 처음 제안되었던 QS는, 보안 취약을 근거로 반려되었으며, userinfo 또한 장점이 느껴지지 않았습니다. 이후 가능한 방법으로는 Server에서 별도 session을 생성하는 것인데, 이 경우 우리가 자체 Auth 서버 및 flow를 디자인하는거라 굳이굳이 + 너무나엄청나!가 되어버립니다.

서버가 OAuth2를 시작하고 끝나는 현 설계에서, code 발급까지를 클라이언트에 위임하는 방향으로 설계 변경이 가능합니다. 다만, 이 방법의 경우 작업량이 많아 차선책을 탐색하게 되었습니다.

URL fragment의 경우, 브라우져 내부에서만 동작하며, referrer 등의 문제가 발생하지 않고, 서버로 전송되지 않아 다른 곳에 로그를 남길 위험도 적습니다. 반면 코드 한 줄 변경으로 손쉽게 구현이 가능합니다. 브라우져 히스토리 관련은 클라이언트에서 알아서 지워줄거라고 믿으며, 해당 방법을 적용합니다.

### Reference

[1] https://neilmadden.blog/2019/01/16/can-you-ever-safely-include-credentials-in-a-url/