### PR TITLE
Fix/remove processed email tasks

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
@@ -26,8 +26,11 @@ public class EmailService {
     public List<EmailTask> getAllTaskAsList() {
         return emailTaskRepository.findAll();
     }
+    public List<EmailTask> getTasksInIds(List<Long> emailIds) {
+        return emailTaskRepository.findAllById(emailIds);
+    }
 
-    public EmailTask getTaskDetails(Long taskId) {
+    public EmailTask findById(Long taskId) {
         return findEmailTaskById(emailTaskRepository, taskId);
     }
 
@@ -68,9 +71,8 @@ public class EmailService {
     }
 
     @Transactional
-    public void deleteAll(List<Long> emailIds) {
-        List<EmailTask> tasks = emailTaskRepository.findAllById(emailIds);
-        emailTaskRepository.deleteAllInBatch(tasks);
+    public void deleteAll(List<EmailTask> emailTasks) {
+        emailTaskRepository.deleteAllInBatch(emailTasks);
     }
 
     private void validateEmailTaskAlreadySent(EmailTask emailTask) {

--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailTaskScheduler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailTaskScheduler.java
@@ -44,7 +44,7 @@ public class EmailTaskScheduler implements TaskScheduler {
                 () -> {
                     transactionTemplate.execute(status -> {
                         try {
-                            EmailTask sendingTask = emailService.getTaskDetails(id);
+                            EmailTask sendingTask = emailService.findById(id);
                             emailClient.sendEmailToReceivers(sendingTask);
                             emailService.markAsCompleted(id);
                         } catch (Exception e) {

--- a/src/main/java/gdsc/konkuk/platformcore/controller/email/EmailController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/email/EmailController.java
@@ -41,7 +41,7 @@ public class EmailController {
     @GetMapping("/{taskId}")
     public ResponseEntity<SuccessResponse> getEmailTask(@PathVariable Long taskId) {
         EmailTaskDetailResponse emailTask = EmailTaskMapper.mapToEmailTaskDetailsResponse(
-                emailService.getTaskDetails(taskId));
+                emailService.findById(taskId));
         return ResponseEntity.ok(SuccessResponse.of(emailTask));
     }
 

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailIntegrationTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailIntegrationTest.java
@@ -162,27 +162,6 @@ class EmailIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 처리된 작업 취소 시도 시 예외 발생")
-    void should_fail_when_cancel_already_processed_task() throws Exception {
-        //given
-        EmailSendRequest emailRequest = EmailSendRequestFixture.builder()
-                .sendAt(LocalDateTime.now().plusSeconds(1)).build()
-                .getFixture();
-
-        //when
-        EmailTask scheduledTask = emailTaskFacade.register(emailRequest);
-        sleep(2_000);
-
-        //then
-        try {
-            emailTaskFacade.cancel(scheduledTask.getId());
-            fail("`TaskNotFoundException` or `EmailAlreadyProcessedException` should be thrown");
-        } catch (TaskNotFoundException | EmailAlreadyProcessedException e) {
-            // pass
-        }
-    }
-
-    @Test
     void should_send_discord_message_when_email_sending_error() throws InterruptedException {
         //given
         EmailSendRequest emailRequest = EmailSendRequestFixture.builder()

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
@@ -60,14 +60,14 @@ class EmailServiceTest {
 
     @Test
     @DisplayName("getTaskDetails : 특정 이메일 전송 작업 조회 성공")
-    void should_success_when_getTaskDetails() {
+    void should_success_when_findById() {
         // given
         EmailTask emailTaskToFind = EmailTaskFixture.builder().build().getFixture();
         given(emailTaskRepository.findById(emailTaskToFind.getId()))
                 .willReturn(java.util.Optional.of(emailTaskToFind));
 
         // when
-        EmailTask actual = subject.getTaskDetails(emailTaskToFind.getId());
+        EmailTask actual = subject.findById(emailTaskToFind.getId());
 
         // then
         assertEquals(emailTaskToFind.getId(), actual.getId());

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailTaskFacadeTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailTaskFacadeTest.java
@@ -1,8 +1,10 @@
 package gdsc.konkuk.platformcore.application.email;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import gdsc.konkuk.platformcore.controller.email.dtos.EmailSendRequest;
@@ -70,6 +72,7 @@ class EmailTaskFacadeTest {
         EmailTask emailTaskToCancel = EmailTaskFixture.builder().build().getFixture();
         willDoNothing().given(emailTaskScheduler).cancelTask(emailTaskToCancel.getId().toString());
         willDoNothing().given(emailService).delete(emailTaskToCancel.getId());
+        when(emailService.findById(any())).thenReturn(emailTaskToCancel);
 
         //when
         subject.cancel(emailTaskToCancel.getId());

--- a/src/test/java/gdsc/konkuk/platformcore/controller/email/EmailControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/email/EmailControllerTest.java
@@ -222,7 +222,7 @@ class EmailControllerTest {
         String jwt = jwtTokenProvider.createToken(member);
         EmailTask emailTaskToSee = EmailTaskFixture.builder()
                 .id(1L).build().getFixture();
-        given(emailService.getTaskDetails(emailTaskToSee.getId()))
+        given(emailService.findById(emailTaskToSee.getId()))
                 .willReturn(emailTaskToSee);
 
         //when


### PR DESCRIPTION
## 작업 내역

  - 이메일 작업 삭제 기능 로직 수정
    - 이미 처리된 작업도 삭제 가능하도록 수정 
  - EmailService 메소드 이름 수정
  - 테스트 코드에 적용

## 연관 이슈

## 전달사항

Task 엔티티와 TaskSendEvent를 나타내는 객체를 분리해야할 것 같습니다. 
추후에 트랜잭션 이후에 도메인 이벤트 발행으로 처리하는게 좋겠네용. 
