### PR TITLE
`v1` : 마무리

### DIFF
--- a/sql/v0.sql
+++ b/sql/v0.sql
@@ -1,220 +1,83 @@
-create table
-    if not exists gdsc.event
+create table if not exists gdsc.event
 (
-    id
-    bigint
-    auto_increment
-    primary
-    key,
-    title
-    varchar
-(
-    255
-) NOT NULL,
-    content text NOT NULL,
-    location varchar
-(
-    255
-) NOT NULL,
-    end_at datetime
-(
-    6
-) NOT NULL,
-    start_at datetime
-(
-    6
-) NOT NULL,
-    retrospect_content text NOT NULL
-    );
+    id                 bigint auto_increment primary key,
+    title              varchar(255) NOT NULL,
+    content            text         NOT NULL,
+    location           varchar(255) NOT NULL,
+    end_at             datetime(6)  NOT NULL,
+    start_at           datetime(6)  NOT NULL,
+    retrospect_content text         NOT NULL
+);
 
-create table
-    if not exists gdsc.event_image
+create table if not exists gdsc.event_image
 (
-    id
-    bigint
-    auto_increment
-    primary
-    key,
-    event_id
-    bigint
-    NOT
-    NULL,
-    url
-    varchar
-(
-    255
-) NOT NULL,
-    CONSTRAINT FOREIGN KEY
-(
-    event_id
-) REFERENCES gdsc.event
-(
-    id
-) ON UPDATE CASCADE
-  ON DELETE CASCADE
-    );
+    id       bigint auto_increment primary key,
+    event_id bigint       NOT NULL,
+    url      varchar(255) NOT NULL,
+    CONSTRAINT FOREIGN KEY (event_id)
+        REFERENCES gdsc.event (id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);
 
-create table
-    if not exists gdsc.attendance
+create table if not exists gdsc.attendance
 (
-    id
-    bigint
-    auto_increment
-    primary
-    key,
-    event_id
-    bigint
-    NOT
-    NULL,
-    active_qr_uuid
-    varchar
-(
-    255
-) NULL,
-    CONSTRAINT FOREIGN KEY
-(
-    event_id
-) REFERENCES gdsc.event
-(
-    id
-) ON UPDATE CASCADE
-  ON DELETE CASCADE
-    );
+    id             bigint auto_increment primary key,
+    event_id       bigint       NOT NULL,
+    active_qr_uuid varchar(255) NULL,
+    CONSTRAINT FOREIGN KEY (event_id)
+        REFERENCES gdsc.event (id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);
 
-create table
-    if not exists gdsc.email_task
+create table if not exists gdsc.email_task
 (
-    task_id
-    bigint
-    auto_increment
-    primary
-    key,
-    is_sent
-    boolean
-    DEFAULT
-    FALSE,
-    send_at
-    datetime
-(
-    6
-) NOT NULL,
-    email_content text NOT NULL,
-    email_subject varchar
-(
-    255
-) NOT NULL
-    );
+    task_id       bigint auto_increment primary key,
+    is_sent       boolean DEFAULT FALSE,
+    send_at       datetime(6)  NOT NULL,
+    email_content text         NOT NULL,
+    email_subject varchar(255) NOT NULL
+);
 
-create table
-    if not exists gdsc.email_receivers
+create table if not exists gdsc.email_receivers
 (
-    task_id
-    bigint
-    NOT
-    NULL,
-    receiver_email
-    varchar
-(
-    255
-) NOT NULL,
-    receiver_name varchar
-(
-    255
-) NOT NULL,
-    CONSTRAINT FOREIGN KEY
-(
-    task_id
-) REFERENCES gdsc.email_task
-(
-    task_id
-) ON UPDATE CASCADE
-  ON DELETE CASCADE
-    );
+    task_id        bigint       NOT NULL,
+    receiver_email varchar(255) NOT NULL,
+    receiver_name  varchar(255) NOT NULL,
+    CONSTRAINT FOREIGN KEY (task_id)
+        REFERENCES gdsc.email_task (task_id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);
 
-create table
-    if not exists gdsc.member
+create table if not exists gdsc.member
 (
-    id
-    bigint
-    auto_increment
-    primary
-    key,
-    member_id
-    varchar
-(
-    255
-) UNIQUE NOT NULL,
-    member_name varchar
-(
-    255
-) NOT NULL,
-    password varchar
-(
-    255
-) NOT NULL,
-    member_role enum
-(
-    'ADMIN',
-    'LEAD',
-    'MEMBER'
-) NOT NULL,
-    batch varchar
-(
-    255
-) NOT NULL,
-    department varchar
-(
-    255
-) NOT NULL,
-    member_email varchar
-(
-    255
-) NOT NULL,
-    is_activated boolean DEFAULT TRUE,
-    is_deleted boolean DEFAULT FALSE,
-    soft_deleted_at datetime
-(
-    6
-) NULL
-    );
+    id              bigint auto_increment primary key,
+    member_id       varchar(255) UNIQUE                NOT NULL,
+    member_name     varchar(255)                       NOT NULL,
+    password        varchar(255)                       NOT NULL,
+    member_role     enum ( 'ADMIN', 'LEAD', 'MEMBER' ) NOT NULL,
+    batch           varchar(255)                       NOT NULL,
+    department      varchar(255)                       NOT NULL,
+    member_email    varchar(255)                       NOT NULL,
+    is_activated    boolean DEFAULT TRUE,
+    is_deleted      boolean DEFAULT FALSE,
+    soft_deleted_at datetime(6)                        NULL
+);
 
-create table
-    if not exists gdsc.participant
+create table if not exists gdsc.participant
 (
-    id
-    bigint
-    auto_increment
-    primary
-    key,
-    member_id
-    bigint
-    NOT
-    NULL,
-    attendance_id
-    bigint
-    NOT
-    NULL,
-    attendance
-    boolean
-    DEFAULT
-    FALSE,
-    CONSTRAINT
-    FOREIGN
-    KEY
-(
-    member_id
-) REFERENCES gdsc.member
-(
-    id
-) ON UPDATE CASCADE
-  ON DELETE CASCADE,
-    CONSTRAINT FOREIGN KEY
-(
-    attendance_id
-) REFERENCES gdsc.attendance
-(
-    id
-)
-  ON UPDATE CASCADE
-  ON DELETE CASCADE
-    );
+    id            bigint auto_increment primary key,
+    member_id     bigint NOT NULL,
+    attendance_id bigint NOT NULL,
+    attendance    boolean DEFAULT FALSE,
+    CONSTRAINT FOREIGN KEY (member_id)
+        REFERENCES gdsc.member (id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT FOREIGN KEY (attendance_id)
+        REFERENCES gdsc.attendance (id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);

--- a/sql/v1.sql
+++ b/sql/v1.sql
@@ -1,0 +1,52 @@
+-- 1. Add new required columns to attendance table
+ALTER TABLE gdsc.attendance
+    ADD COLUMN title           varchar(255) NULL,
+    ADD COLUMN attendance_time datetime(6)  NULL;
+
+-- 2. Migrate data from event table to attendance table
+UPDATE gdsc.attendance a
+    JOIN gdsc.event e ON a.event_id = e.id
+SET a.title           = e.title,
+    a.attendance_time = e.start_at;
+
+-- 3. Modify member table
+-- 3.1. Rename member_id to student_id
+ALTER TABLE gdsc.member
+    RENAME COLUMN member_id TO student_id;
+
+-- 3.2. Modify ENUM to include new value and update data
+ALTER TABLE gdsc.member
+    MODIFY COLUMN member_role enum ('ADMIN', 'CORE', 'LEAD', 'MEMBER') NOT NULL;
+
+UPDATE gdsc.member
+SET member_role = 'CORE'
+WHERE member_role = 'ADMIN';
+
+-- 4. Modify participant table
+-- 4.1. Add attendance_type column
+ALTER TABLE gdsc.participant
+    ADD COLUMN attendance_type enum ('ATTEND', 'ABSENT', 'LATE') NOT NULL DEFAULT 'ABSENT';
+
+-- 4.2. Convert existing boolean data to ENUM
+UPDATE gdsc.participant
+SET attendance_type =
+        IF(attendance = TRUE, 'ATTEND', 'ABSENT');
+
+-- 5. Remove old columns and modify new columns as required
+-- 5.1. Drop event-related tables
+DROP TABLE IF EXISTS gdsc.event_image;
+DROP TABLE IF EXISTS gdsc.event;
+
+-- 5.2. Remove event_id from attendance table
+ALTER TABLE gdsc.attendance
+    DROP COLUMN event_id;
+
+-- 5.3. Remove password column from member table
+ALTER TABLE gdsc.member
+    DROP COLUMN password;
+
+-- 5.4. Remove attendance column from participant table
+ALTER TABLE gdsc.participant
+    DROP COLUMN attendance;
+
+-- 6. Migration complete

--- a/src/main/java/gdsc/konkuk/platformcore/application/attendance/AttendanceService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/attendance/AttendanceService.java
@@ -31,10 +31,10 @@ public class AttendanceService {
     private final ParticipantService participantService;
 
     @Transactional
-    public Participant attend(Long memberId, Long attendanceId, String qrUuid) {
+    public Participant attend(String memberEmail, Long attendanceId, String qrUuid) {
         Member member =
                 memberRepository
-                        .findById(memberId)
+                        .findByEmail(memberEmail)
                         .orElseThrow(
                                 () -> UserNotFoundException.of(MemberErrorCode.USER_NOT_FOUND));
         Attendance attendance = findAttendanceById(attendanceRepository, attendanceId);

--- a/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/auth/CustomAuthenticationSuccessHandler.java
@@ -36,6 +36,8 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        // TODO: Admin이 아닌 여러 클라이언트를 사용하게 될 경우, authorization code를 통한 POST 로그인으로 변경 필요
         response.sendRedirect(SPA_ADMIN_LOGIN_REDIRECT_URL + "#" + token);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/auth/JwtAuthenticationFilter.java
@@ -35,7 +35,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.error("[ERROR] : 인증 정보가 유효하지 않습니다.", e);
             SecurityContextHolder.clearContext();
         } catch (IllegalArgumentException ignored) {
-            SecurityContextHolder.clearContext();
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
@@ -14,7 +14,6 @@ import gdsc.konkuk.platformcore.controller.attendance.dtos.AttendanceRegisterReq
 import gdsc.konkuk.platformcore.controller.attendance.dtos.AttendanceResponse;
 import gdsc.konkuk.platformcore.domain.attendance.entity.Attendance;
 import gdsc.konkuk.platformcore.global.responses.SuccessResponse;
-import gdsc.konkuk.platformcore.global.utils.SecurityUtils;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URI;
 import java.time.LocalDate;
@@ -22,6 +21,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,10 +51,10 @@ public class AttendanceController {
     }
 
     @GetMapping("/attend/{attendanceId}")
-    public ResponseEntity<?> attend(@PathVariable Long attendanceId, @RequestParam String qrUuid) {
+    public ResponseEntity<?> attend(@AuthenticationPrincipal OidcUser oidcUser,
+            @PathVariable Long attendanceId, @RequestParam String qrUuid) {
         try {
-            Long currentId = SecurityUtils.getCurrentUserId();
-            attendanceService.attend(currentId, attendanceId, qrUuid);
+            attendanceService.attend(oidcUser.getEmail(), attendanceId, qrUuid);
             HttpHeaders headers = new HttpHeaders();
             headers.add("Location", SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL);
             return new ResponseEntity<>(headers,

--- a/src/main/java/gdsc/konkuk/platformcore/global/configs/SecurityConfig.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/configs/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(
                                 (request, response, authException) ->
-                                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED))
+                                        response.sendRedirect("/login/oauth2/authorization/google"))
                         .accessDeniedHandler(
                                 (request, response, accessDeniedException) ->
                                         response.setStatus(HttpServletResponse.SC_FORBIDDEN)))

--- a/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
@@ -144,7 +144,7 @@ class AttendanceControllerTest {
                 .email("ex@gmail.com").build().getFixture();
         Attendance attendanceToAttend = AttendanceFixture.builder()
                 .id(1L).activeQrUuid("uuid").build().getFixture();
-        given(attendanceService.attend(memberToAttend.getId(), attendanceToAttend.getId(),
+        given(attendanceService.attend(memberToAttend.getEmail(), attendanceToAttend.getId(),
                 attendanceToAttend.getActiveQrUuid()))
                 .willReturn(ParticipantFixture.builder()
                         .attendanceType(AttendanceType.ATTEND)

--- a/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceControllerTest.java
@@ -142,7 +142,6 @@ class AttendanceControllerTest {
         // given
         Member memberToAttend = MemberFixture.builder()
                 .email("ex@gmail.com").build().getFixture();
-        String jwt = jwtTokenProvider.createToken(memberToAttend);
         Attendance attendanceToAttend = AttendanceFixture.builder()
                 .id(1L).activeQrUuid("uuid").build().getFixture();
         given(attendanceService.attend(memberToAttend.getId(), attendanceToAttend.getId(),
@@ -158,7 +157,6 @@ class AttendanceControllerTest {
                 mockMvc.perform(
                         RestDocumentationRequestBuilders.get(
                                         "/api/v1/attendances/attend/{attendanceId}", 1L)
-                                .header("Authorization", "Bearer " + jwt)
                                 .queryParam("qrUuid", "uuid")
                                 .with(oidcLogin()
                                         .idToken(token -> token.claim("email", "ex@gmail.com"))));


### PR DESCRIPTION
이번 PR을 마무리로 v1 완료네요. 고생하셨습니다! 
남아있는 #68 이나, Discord Webhook과 같은 부가적인 기능은 조금 더 여유를 두고 차차 진행해보도록 합시다.

### 한 일

- resolve #56 , OCI 인스턴스 이사는 완료해두었습니다. `mysqldump` 파일은 `${workspace}/sql/v0.x.sql`에서 확인하실 수 있습니다.
- 사용자 출석 과정에서 자연스럽게 로그인을 진행해야 하는데, 중간 리팩터링으로 401을 반환하던 문제를 해결했습니다. 관리자 API와 출석 API를 동일하게 인증하도록 설정했었는데, 둘의 사용자 flow는 매우 달랐네요.

### Note

기존 OCI 인스턴스는 혹시 모를 사고를 생각해 3일 정도 유예를 둔 후 삭제할 예정입니다.
