### PR TITLE
feat: OracleDB Migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,10 @@ dependencies {
 
     // Database
     runtimeOnly 'com.h2database:h2:2.2.224'
-    implementation 'mysql:mysql-connector-java:8.0.32'
+	implementation 'com.oracle.database.security:oraclepki:21.1.0.0'
+	implementation 'com.oracle.database.security:osdt_core:21.1.0.0'
+	implementation 'com.oracle.database.security:osdt_cert:21.1.0.0'
+    implementation 'com.oracle.database.jdbc:ojdbc11:21.9.0.0'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1'
 
     // Lombok

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailDetail.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailDetail.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.persistence.Lob;
 
 @Embeddable
 @Getter
@@ -18,7 +19,8 @@ public class EmailDetail {
     @Column(name = "email_subject")
     private String subject;
 
-    @Column(name = "email_content", columnDefinition = "TEXT")
+    @Lob
+    @Column(name = "email_content", columnDefinition = "CLOB")
     private String content;
 
     @Builder

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTask.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailTask.java
@@ -2,7 +2,9 @@ package gdsc.konkuk.platformcore.domain.email.entity;
 
 import static gdsc.konkuk.platformcore.global.utils.FieldValidator.validateNotNull;
 
+import gdsc.konkuk.platformcore.global.utils.BooleanToIntegerConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -32,7 +34,8 @@ public class EmailTask {
     private LocalDateTime sendAt;
 
     @Column(name = "is_sent")
-    private boolean isSent = false;
+    @Convert(converter = BooleanToIntegerConverter.class)
+    private Boolean isSent = false;
 
     @Builder
     public EmailTask(
@@ -56,5 +59,9 @@ public class EmailTask {
 
     public Long getLastWaitingPeriodInSeconds() {
         return ChronoUnit.SECONDS.between(LocalDateTime.now(), this.sendAt);
+    }
+
+    public Boolean isSent() {
+        return isSent;
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/entity/Member.java
@@ -7,6 +7,7 @@ import gdsc.konkuk.platformcore.application.member.dtos.MemberUpdateCommand;
 import gdsc.konkuk.platformcore.application.member.exceptions.MemberErrorCode;
 import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyDeletedException;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -19,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+import gdsc.konkuk.platformcore.global.utils.BooleanToIntegerConverter;
 
 @Entity
 @SQLRestriction("is_deleted = false")
@@ -43,7 +45,12 @@ public class Member {
     private String department;
 
     @Column(name = "is_deleted")
-    private boolean isDeleted = false;
+    @Convert(converter = BooleanToIntegerConverter.class)
+    private Boolean isDeleted = false;
+
+    @Column(name = "is_activated")
+    @Convert(converter = BooleanToIntegerConverter.class)
+    private Boolean isActivated = true;
 
     @Column(name = "soft_deleted_at")
     private LocalDateTime softDeletedAt;

--- a/src/main/java/gdsc/konkuk/platformcore/global/utils/BooleanToIntegerConverter.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/utils/BooleanToIntegerConverter.java
@@ -1,0 +1,16 @@
+package gdsc.konkuk.platformcore.global.utils;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class BooleanToIntegerConverter implements AttributeConverter<Boolean, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(Boolean attribute) {
+        return Boolean.TRUE.equals(attribute) ? 1 : 0;
+    }
+    @Override
+    public Boolean convertToEntityAttribute(Integer dbData) {
+        return Integer.valueOf(1).equals(dbData);
+    }
+} 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -8,10 +8,14 @@ server:
 
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${ORACLE_URL}
+    username: ${ORACLE_USERNAME}
+    password: ${ORACLE_PASSWORD}
+    driver-class-name: oracle.jdbc.OracleDriver
   jpa:
     hibernate:
       ddl-auto: validate
+    database-platform: org.hibernate.dialect.OracleDialect
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
- MySQL은 Boolean 타입을 엔진에서 내부적으로 TINYINT(1)로 자동 매핑해준다. (명시적인 Boolean타입의 컬럼이 있지 않음)
- Oracle에서도 Boolean 타입을 컬럼으로 지원하지 않는데 매핑도 해주지 않아 직접 변환하여 저장해야 한다.
- 서비스 코드의 수정은 필요하지 않도록 도메인 필드 값은 Boolean타입으로 유지하되, Converter를 추가하여 DB에 저장시에 NUMBER타입으로 저장되도록 처리
- Jdbc Connection 관련 환경 변수들도 Oracle DB에 알맞도록 수정