### PR TITLE
[Fix] - cicd 중 docker compose build 단계에서 사용할 임시 값 지정

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,7 +2,7 @@ services:
   spring:
     image: ghcr.io/chabinhwang/platform-core:latest
     volumes:
-      - ${ORACLE_WALLET_PATH}:/app/wallet
+      - ${ORACLE_WALLET_PATH:-/tmp/wallet}:/app/wallet
     container_name: spring
     restart: always
     logging:


### PR DESCRIPTION
github action 오류 이유 :  빈 문자열("")은 환경변수 값으로는 허용되지만, 볼륨의 호스트 경로는 비울 수 없음
따라서 아래 방식으로 해결하였습니다.

1. 빌드 단계 (GitHub Actions 등)
ORACLE_WALLET_PATH 환경 변수가 설정되어 있지 않으면 /tmp/wallet을 사용
2. 실제 서버에서 docker compose up 실행 시
ORACLE_WALLET_PATH 값이 지정되어 있으면 그 값을 우선 사용